### PR TITLE
Honor glm-copilot.region in Coding Plan mode (add Mainland China coding endpoint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to GLM for Copilot Chat are documented here.
 
 ## Unreleased
 
+- **Mainland China Coding Plan** — `region: china` now routes Coding Plan requests to `open.bigmodel.cn/api/coding/paas/v4` instead of z.ai, and `GLM: Get API Key` opens the bigmodel.cn coding-plan console. International Coding Plan and all Standard endpoints are unchanged; `region` defaults to `international`, so existing users are unaffected.
+
 ## 0.2.1
 
 - **Live thinking stream fix** — request `Accept-Encoding: identity` so z.ai's (nginx) edge does not gzip-buffer the SSE stream. Without it, `reasoning_content` deltas arrived batched and the "Thinking…" block only appeared after reasoning finished; now thinking tokens render live as they generate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to GLM for Copilot Chat are documented here.
 
+## Unreleased
+
 ## 0.2.1
 
 - **Live thinking stream fix** — request `Accept-Encoding: identity` so z.ai's (nginx) edge does not gzip-buffer the SSE stream. Without it, `reasoning_content` deltas arrived batched and the "Thinking…" block only appeared after reasoning finished; now thinking tokens render live as they generate.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The picker shows only the models available for your selected **API Mode**, so yo
 | Setting | Default | Description |
 |---|---|---|
 | `glm-copilot.apiMode` | `coding-plan` | Which GLM API to use: `coding-plan` or `standard`. See below. |
-| `glm-copilot.region` | `international` | Region for Standard API mode: `international` (z.ai) or `china` (bigmodel.cn). Ignored in Coding Plan mode. |
+| `glm-copilot.region` | `international` | Server region for **both** API modes: `international` (z.ai) or `china` (bigmodel.cn). Ignored only when `baseUrl` is set. |
 | `glm-copilot.baseUrl` | *(empty)* | Override the API base URL. Overrides `apiMode` and `region`. Use for proxies or compatible APIs. |
 | `glm-copilot.maxTokens` | `0` | Maximum output tokens per request. `0` means no explicit limit (uses API default). |
 | `glm-copilot.thinking` | `enabled` | Step-by-step reasoning: `enabled` (higher quality) or `disabled` (faster). Applies to models that support thinking. |
@@ -110,13 +110,14 @@ The picker shows only the models available for your selected **API Mode**, so yo
 
 ### Coding Plan
 
-Requires a [Z.ai GLM Coding Plan](https://z.ai/manage-apikey/subscription) subscription. All requests go to:
+Requires a GLM Coding Plan subscription. The endpoint depends on your `region`:
 
-```
-https://api.z.ai/api/coding/paas/v4
-```
+| Region | Endpoint | Key page |
+|---|---|---|
+| International | `https://api.z.ai/api/coding/paas/v4` | [z.ai/manage-apikey/subscription](https://z.ai/manage-apikey/subscription) |
+| Mainland China | `https://open.bigmodel.cn/api/coding/paas/v4` | [bigmodel.cn/coding-plan](https://bigmodel.cn/coding-plan/personal/overview) |
 
-The `region` setting is ignored in this mode. Best for teams or high-volume coding workflows.
+Best for teams or high-volume coding workflows.
 
 ### Standard API
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Use your own GLM API key (BYOK) to bring Zhipu AI's GLM models into GitHub Copil
 
 - **Don't replace Copilot — power it up.** GLM models appear alongside GPT-4o, Claude, and others in the existing model picker.
 - **Agent mode, tool calling, instructions, MCP — all still work.** Copilot's full stack now runs on GLM.
+- **Watch GLM think.** The model's step-by-step reasoning streams into the chat — a transparency Copilot's built-in BYOK doesn't expose.
 - **BYOK, your bill.** Your API key lives in the OS keychain, never in `settings.json` or your Git history.
 - **Dual API.** Use your GLM Coding Plan subscription or the pay-as-you-go Standard API, whichever fits your workflow.
 - **Zero runtime dependencies.** Pure VS Code API and Node.js built-ins. No Python, no Docker, no local server.

--- a/docs/glm-api.md
+++ b/docs/glm-api.md
@@ -25,7 +25,8 @@ Append `/chat/completions` to any base URL below.
 
 | Mode | Region | Base URL |
 | --- | --- | --- |
-| Coding Plan | — (z.ai only) | `https://api.z.ai/api/coding/paas/v4` |
+| Coding Plan | International | `https://api.z.ai/api/coding/paas/v4` |
+| Coding Plan | Mainland China | `https://open.bigmodel.cn/api/coding/paas/v4` |
 | Standard | International | `https://api.z.ai/api/paas/v4` |
 | Standard | Mainland China | `https://open.bigmodel.cn/api/paas/v4` |
 
@@ -74,7 +75,8 @@ sent back as `role: "tool"` messages with the matching `tool_call_id`.
 
 | Mode / Region | Where to get a key |
 | --- | --- |
-| Coding Plan | <https://z.ai/manage-apikey/subscription> |
+| Coding Plan — International | <https://z.ai/manage-apikey/subscription> |
+| Coding Plan — Mainland China | <https://bigmodel.cn/coding-plan/personal/overview> |
 | Standard — International | <https://z.ai/manage-apikey/apikey-list> |
 | Standard — Mainland China | <https://open.bigmodel.cn/usercenter/proj-mgmt/apikeys> |
 

--- a/llms.txt
+++ b/llms.txt
@@ -11,7 +11,7 @@ Key facts:
 - **Type:** VS Code extension (Marketplace), published under the `glm-copilot` publisher.
 - **What it does:** lets you use GLM models inside GitHub Copilot Chat without replacing Copilot's UI.
 - **How it works:** implements `vscode.LanguageModelChatProvider`; streams OpenAI-compatible SSE from the GLM API.
-- **Dual API:** choose your **GLM Coding Plan** subscription or the pay-as-you-go **Standard API** (International `z.ai` or Mainland China `bigmodel.cn`).
+- **Dual API:** choose your **GLM Coding Plan** subscription or the pay-as-you-go **Standard API** — each available International (`z.ai`) or Mainland China (`bigmodel.cn`).
 - **BYOK and secure:** your API key is stored in the OS keychain via VS Code `SecretStorage`, never in `settings.json`.
 - **Thinking mode:** GLM step-by-step reasoning streams live as a Thinking block.
 - **Zero runtime dependencies:** pure VS Code API and Node.js built-ins.
@@ -35,5 +35,5 @@ Key facts:
 ## External
 
 - [GLM API documentation (Z.ai)](https://docs.z.ai)
-- [GLM Coding Plan](https://z.ai/manage-apikey/subscription)
+- GLM Coding Plan: [International (Z.ai)](https://z.ai/manage-apikey/subscription) · [Mainland China (bigmodel.cn)](https://bigmodel.cn/coding-plan/personal/overview)
 - [GitHub Copilot](https://github.com/features/copilot)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "glm-for-copilot",
 	"displayName": "GLM for Copilot Chat",
-	"description": "Use GLM (Z.ai / Zhipu) models in GitHub Copilot Chat — your GLM Coding Plan or the standard GLM API. Thinking mode, tool calling, BYOK.",
+	"description": "Bring GLM (Z.ai / Zhipu) models into GitHub Copilot Chat with visible thinking. Coding Plan or Standard API.",
 	"icon": "resources/icon.png",
 	"version": "0.2.1",
 	"publisher": "QiYijiazhen",

--- a/package.nls.json
+++ b/package.nls.json
@@ -12,20 +12,20 @@
   "glm-copilot.walkthrough.setApiKey.description": "[Get an API key](command:glm-copilot.getApiKey) from z.ai or bigmodel.cn.\n[Set API Key](command:glm-copilot.setApiKey)",
 
   "glm-copilot.walkthrough.chooseApi.title": "Choose your GLM API",
-  "glm-copilot.walkthrough.chooseApi.description": "Select between the GLM Coding Plan and the Standard API, and choose your region if you are using Standard mode.\n[Open settings](command:glm-copilot.openSettings)",
+  "glm-copilot.walkthrough.chooseApi.description": "Select between the GLM Coding Plan and the Standard API, and choose your region.\n[Open settings](command:glm-copilot.openSettings)",
 
   "glm-copilot.walkthrough.showModels.title": "Show GLM models in the picker",
   "glm-copilot.walkthrough.showModels.description": "Your GLM models appear in the Copilot Chat model picker, filtered by your selected API Mode. If they are hidden, open the Language Models manager to show them.\n[Open Language Models](command:workbench.action.chat.manage)",
 
   "glm-copilot.config.title": "GLM Copilot",
 
-  "glm-copilot.config.apiMode.description": "Which GLM API to use.\n\n- **Coding Plan** — uses your [Z.ai GLM Coding Plan](https://z.ai/manage-apikey/subscription) subscription. Endpoint: `api.z.ai/api/coding/paas/v4`. Best for teams or heavy coding use.\n- **Standard API** — pay-as-you-go access via the GLM Open Platform. The active endpoint depends on the `region` setting.",
+  "glm-copilot.config.apiMode.description": "Which GLM API to use.\n\n- **Coding Plan** — uses your GLM Coding Plan subscription ([Z.ai](https://z.ai/manage-apikey/subscription) International or [bigmodel.cn](https://bigmodel.cn/coding-plan/personal/overview) Mainland China). The active endpoint depends on the `region` setting. Best for teams or heavy coding use.\n- **Standard API** — pay-as-you-go access via the GLM Open Platform. The active endpoint depends on the `region` setting.",
   "glm-copilot.config.apiMode.codingPlan.label": "Coding Plan",
-  "glm-copilot.config.apiMode.codingPlan.description": "Use your Z.ai GLM Coding Plan subscription (`api.z.ai/api/coding/paas/v4`). The `region` setting is ignored in this mode.",
+  "glm-copilot.config.apiMode.codingPlan.description": "Use your GLM Coding Plan subscription. The endpoint depends on `region`: International → `api.z.ai/api/coding/paas/v4`, Mainland China → `open.bigmodel.cn/api/coding/paas/v4`.",
   "glm-copilot.config.apiMode.standard.label": "Standard API",
   "glm-copilot.config.apiMode.standard.description": "Pay-as-you-go access via the GLM Open Platform. The active endpoint is chosen by the `region` setting.",
 
-  "glm-copilot.config.region.description": "Region for **Standard API** mode. Ignored when `apiMode` is `Coding Plan`.\n\n- **International** — `api.z.ai/api/paas/v4` (requires a Z.ai account)\n- **Mainland China** — `open.bigmodel.cn/api/paas/v4` (requires a Zhipu AI account)",
+  "glm-copilot.config.region.description": "Server region for **Coding Plan** and **Standard API** modes (ignored when `baseUrl` is set).\n\n- **International** (Z.ai account) — Coding Plan `api.z.ai/api/coding/paas/v4`, Standard `api.z.ai/api/paas/v4`\n- **Mainland China** (Zhipu AI account) — Coding Plan `open.bigmodel.cn/api/coding/paas/v4`, Standard `open.bigmodel.cn/api/paas/v4`",
   "glm-copilot.config.region.international.label": "International (z.ai)",
   "glm-copilot.config.region.china.label": "Mainland China (bigmodel.cn)",
 

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -12,20 +12,20 @@
   "glm-copilot.walkthrough.setApiKey.description": "[获取 API 密钥](command:glm-copilot.getApiKey)（来自 z.ai 或 bigmodel.cn）。\n[设置 API 密钥](command:glm-copilot.setApiKey)",
 
   "glm-copilot.walkthrough.chooseApi.title": "选择 GLM API 模式",
-  "glm-copilot.walkthrough.chooseApi.description": "在 GLM 编程计划和标准 API 之间选择，并在使用标准模式时选择您的区域。\n[打开设置](command:glm-copilot.openSettings)",
+  "glm-copilot.walkthrough.chooseApi.description": "在 GLM 编程计划和标准 API 之间选择，并选择您的区域。\n[打开设置](command:glm-copilot.openSettings)",
 
   "glm-copilot.walkthrough.showModels.title": "在选择器中查看 GLM 模型",
   "glm-copilot.walkthrough.showModels.description": "你的 GLM 模型将根据所选的 API 模式出现在 Copilot Chat 的模型选择器中。如果看不到，请打开语言模型管理器以显示它们。\n[打开语言模型](command:workbench.action.chat.manage)",
 
   "glm-copilot.config.title": "GLM Copilot",
 
-  "glm-copilot.config.apiMode.description": "选择要使用的 GLM API。\n\n- **编程计划** — 使用您的 [Z.ai GLM 编程计划](https://z.ai/manage-apikey/subscription)订阅，端点为 `api.z.ai/api/coding/paas/v4`，适合团队或高频编码场景。\n- **标准 API** — 按量付费，通过 GLM 开放平台访问，实际端点取决于 `region` 设置。",
+  "glm-copilot.config.apiMode.description": "选择要使用的 GLM API。\n\n- **编程计划** — 使用您的 GLM 编程计划订阅（[Z.ai](https://z.ai/manage-apikey/subscription) 国际版或 [bigmodel.cn](https://bigmodel.cn/coding-plan/personal/overview) 中国大陆）。实际端点取决于 `region` 设置，适合团队或高频编码场景。\n- **标准 API** — 按量付费，通过 GLM 开放平台访问，实际端点取决于 `region` 设置。",
   "glm-copilot.config.apiMode.codingPlan.label": "编程计划",
-  "glm-copilot.config.apiMode.codingPlan.description": "使用 Z.ai GLM 编程计划订阅（`api.z.ai/api/coding/paas/v4`）。此模式下 `region` 设置将被忽略。",
+  "glm-copilot.config.apiMode.codingPlan.description": "使用 GLM 编程计划订阅。端点取决于 `region`：国际版 → `api.z.ai/api/coding/paas/v4`，中国大陆 → `open.bigmodel.cn/api/coding/paas/v4`。",
   "glm-copilot.config.apiMode.standard.label": "标准 API",
   "glm-copilot.config.apiMode.standard.description": "通过 GLM 开放平台按量付费访问，实际端点由 `region` 设置决定。",
 
-  "glm-copilot.config.region.description": "**标准 API** 模式下使用的区域，`apiMode` 为编程计划时忽略此设置。\n\n- **国际版** — `api.z.ai/api/paas/v4`（需要 Z.ai 账号）\n- **中国大陆** — `open.bigmodel.cn/api/paas/v4`（需要智谱 AI 账号）",
+  "glm-copilot.config.region.description": "**编程计划**与**标准 API** 模式下使用的服务器区域（设置 `baseUrl` 时忽略）。\n\n- **国际版**（Z.ai 账号）— 编程计划 `api.z.ai/api/coding/paas/v4`，标准 `api.z.ai/api/paas/v4`\n- **中国大陆**（智谱 AI 账号）— 编程计划 `open.bigmodel.cn/api/coding/paas/v4`，标准 `open.bigmodel.cn/api/paas/v4`",
   "glm-copilot.config.region.international.label": "国际版 (z.ai)",
   "glm-copilot.config.region.china.label": "中国大陆 (bigmodel.cn)",
 

--- a/resources/walkthrough/choose-api.md
+++ b/resources/walkthrough/choose-api.md
@@ -1,8 +1,8 @@
 ## Coding Plan
 
-Use this if you have a [Z.ai GLM Coding Plan](https://z.ai/manage-apikey/subscription) subscription. All requests go to `api.z.ai/api/coding/paas/v4`. The `region` setting is ignored in this mode.
+Use this if you have a GLM Coding Plan subscription. The endpoint follows your `region`: International (`z.ai`) → `api.z.ai/api/coding/paas/v4`, Mainland China (`bigmodel.cn`) → `open.bigmodel.cn/api/coding/paas/v4`. Get your key at [z.ai/manage-apikey/subscription](https://z.ai/manage-apikey/subscription) (International) or [bigmodel.cn/coding-plan](https://bigmodel.cn/coding-plan/personal/overview) (Mainland China).
 
-Set `glm-copilot.apiMode` to **Coding Plan** in settings.
+Set `glm-copilot.apiMode` to **Coding Plan** and pick the matching `glm-copilot.region` in settings.
 
 ## Standard API
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -26,16 +26,18 @@ export const LANGUAGE_MODEL_CHAT_SYSTEM_ROLE = 3;
 /** Default maximum number of tools accepted in one request. */
 export const DEFAULT_TOOLS_LIMIT = 128;
 
-/** Base hostnames + endpoint paths for each API mode. */
+/** Base hostnames + endpoint paths for each API mode × region. */
 export const ENDPOINTS = {
-	codingPlan: 'https://api.z.ai/api/coding/paas/v4',
+	codingPlanInternational: 'https://api.z.ai/api/coding/paas/v4',
+	codingPlanChina: 'https://open.bigmodel.cn/api/coding/paas/v4',
 	standardInternational: 'https://api.z.ai/api/paas/v4',
 	standardChina: 'https://open.bigmodel.cn/api/paas/v4',
 } as const;
 
 /** External URLs the extension links to. */
 export const EXTERNAL_URLS = {
-	codingPlanKeys: 'https://z.ai/manage-apikey/subscription',
+	codingPlanKeysInternational: 'https://z.ai/manage-apikey/subscription',
+	codingPlanKeysChina: 'https://bigmodel.cn/coding-plan/personal/overview',
 	standardKeysInternational: 'https://z.ai/manage-apikey/apikey-list',
 	standardKeysChina: 'https://open.bigmodel.cn/usercenter/proj-mgmt/apikeys',
 	docs: 'https://docs.z.ai',

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -14,18 +14,18 @@ export function resolveBaseUrl(): string {
 	if (override) {
 		return normalizeBaseUrl(override);
 	}
+	const china = getRegion() === 'china';
 	if (getApiMode() === 'coding-plan') {
-		return ENDPOINTS.codingPlan;
+		return china ? ENDPOINTS.codingPlanChina : ENDPOINTS.codingPlanInternational;
 	}
-	return getRegion() === 'china' ? ENDPOINTS.standardChina : ENDPOINTS.standardInternational;
+	return china ? ENDPOINTS.standardChina : ENDPOINTS.standardInternational;
 }
 
 /** The key-management page that matches the current apiMode/region. */
 export function resolveKeyPageUrl(): string {
+	const china = getRegion() === 'china';
 	if (getApiMode() === 'coding-plan') {
-		return EXTERNAL_URLS.codingPlanKeys;
+		return china ? EXTERNAL_URLS.codingPlanKeysChina : EXTERNAL_URLS.codingPlanKeysInternational;
 	}
-	return getRegion() === 'china'
-		? EXTERNAL_URLS.standardKeysChina
-		: EXTERNAL_URLS.standardKeysInternational;
+	return china ? EXTERNAL_URLS.standardKeysChina : EXTERNAL_URLS.standardKeysInternational;
 }


### PR DESCRIPTION
## Summary

Coding Plan mode previously ignored `glm-copilot.region` and always sent requests to z.ai. It now routes by region, exactly like Standard mode:

- `coding-plan` + `region: china` → `https://open.bigmodel.cn/api/coding/paas/v4`
- `coding-plan` + `region: international` → `https://api.z.ai/api/coding/paas/v4` (unchanged)
- `GLM: Get API Key` now opens the region-appropriate coding-plan page (mainland → `https://bigmodel.cn/coding-plan/personal/overview`).
- Settings text (EN + zh-CN), README, walkthrough, `docs/glm-api.md`, and `llms.txt` updated so nothing states "region is ignored in Coding Plan mode." Changelog entry added.
- `glm-copilot.baseUrl` override still wins over both modes. `region` defaults to `international`, so existing users see no change.

**Console URL correction:** the issue tentatively guessed `open.bigmodel.cn/usercenter/glm-coding/my-plan`. Verified against the official BigModel docs, the correct page is `https://bigmodel.cn/coding-plan/personal/overview` (the documented "create API key" page for the personal coding plan). The mainland endpoint itself was confirmed both in the official docs and via an unauthenticated route probe (401 on `/api/coding/paas/v4` vs a 200 catch-all on a fake version path).

This branch also includes one unrelated copy-polish commit (`docs: tighten extension copy and open Unreleased changelog`) for README/CHANGELOG/package.json wording.

## Test Plan

- [x] `pnpm exec tsc -p ./` — clean
- [x] `pnpm exec vsce package` — packages successfully (CI "Typecheck and package")
- [ ] Set `apiMode: coding-plan` + `region: china`; confirm via `GLM: Show Logs` that requests hit `open.bigmodel.cn`
- [ ] `region: international` still hits `api.z.ai` (unchanged)
- [ ] `GLM: Get API Key` opens the correct regional page in each mode
- [ ] `glm-copilot.baseUrl` override still wins over mode/region

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coding Plan now supports region-specific endpoints: users can select between International (via z.ai) and Mainland China (via bigmodel.cn) regions, with each offering dedicated API endpoints and key management portals.

* **Documentation**
  * Updated documentation, README, settings descriptions, and walkthrough guides to explain how the region setting affects Coding Plan endpoint selection and API key management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->