### PR TITLE
GLM-5.2 Thinking Effort picker + Standard availability + 1M context (v0.2.2)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,6 +7,7 @@ tsconfig.json
 .gitignore
 .npmrc
 .vscodeignore
+.claude/**
 PLAN.md
 pnpm-lock.yaml
 dist/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to GLM for Copilot Chat are documented here.
 
 - **Mainland China Coding Plan** — `region: china` now routes Coding Plan requests to `open.bigmodel.cn/api/coding/paas/v4` instead of z.ai, and `GLM: Get API Key` opens the bigmodel.cn coding-plan console. International Coding Plan and all Standard endpoints are unchanged; `region` defaults to `international`, so existing users are unaffected.
 
+## 0.2.2
+
+- **GLM-5.2 Thinking Effort picker** — GLM-5.2 gains a per-model Thinking Effort control (None / High / Max) in the Copilot model picker. None turns thinking off; High and Max select how deeply the model reasons. The choice persists per model.
+- **GLM-5.2 on the Standard API** — GLM-5.2 is now available on the Standard API in addition to the Coding Plan, so it appears in the picker under both API modes.
+- **GLM-5.2 context window** — updated to 1M tokens.
+
 ## 0.2.1
 
 - **Live thinking stream fix** — request `Accept-Encoding: identity` so z.ai's (nginx) edge does not gzip-buffer the SSE stream. Without it, `reasoning_content` deltas arrived batched and the "Thinking…" block only appeared after reasoning finished; now thinking tokens render live as they generate.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add your own GLM model ids with the `glm-copilot.customModels` setting — usefu
 
 ### Thinking mode
 
-GLM models support a thinking (step-by-step reasoning) mode, controlled by the `glm-copilot.thinking` setting (`enabled` by default). Set it to `disabled` for faster responses on simple edits.
+GLM models support a thinking (step-by-step reasoning) mode, controlled by the `glm-copilot.thinking` setting (`enabled` by default). Set it to `disabled` for faster responses on simple edits. GLM-5.2 adds a per-model **Thinking Effort** picker (None / High / Max) in the Copilot model picker, and the choice persists per model.
 
 ### Secure API key storage
 
@@ -88,10 +88,10 @@ To update or remove the key later, use **GLM: Set API Key** or **GLM: Clear API 
 | **GLM-4.7** | 200K | 128K | Coding Plan + Standard | Yes | Yes |
 | **GLM-5** | 200K | 128K | Standard only | Yes | Yes |
 | **GLM-5.1** | 200K | 128K | Standard only | Yes | Yes |
-| **GLM-5.2** | 200K | 128K | Coding Plan only | Yes | Yes |
+| **GLM-5.2** | 1M | 128K | Coding Plan + Standard | Yes | Yes (effort) |
 | **GLM-4.5 Air** | 128K | 96K | Coding Plan + Standard | Yes | Yes |
 
-The picker shows only the models available for your selected **API Mode**, so you never pick a model your plan can't serve. GLM-5/5.1 are Standard-API only; GLM-5.2 is Coding-Plan only; GLM-4.7 and GLM-4.5 Air work on both. Need another model? Add it with [`glm-copilot.customModels`](#settings).
+The picker shows only the models available for your selected **API Mode**, so you never pick a model your plan can't serve. GLM-5/5.1 are Standard-API only; GLM-4.7, GLM-5.2, and GLM-4.5 Air work on both. Need another model? Add it with [`glm-copilot.customModels`](#settings).
 
 ## Settings
 
@@ -160,7 +160,7 @@ Pick **Coding Plan** if you have a [Z.ai GLM Coding Plan](https://z.ai/manage-ap
 
 ### Why don't I see a model I expected in the picker?
 
-The picker shows only the models available for your selected **API Mode**. GLM-5 and GLM-5.1 are Standard-API only; GLM-5.2 is Coding-Plan only; GLM-4.7 and GLM-4.5 Air work on both. To force-add any model (including new or proxy-hosted ones), use the [`glm-copilot.customModels`](#settings) setting.
+The picker shows only the models available for your selected **API Mode**. GLM-5 and GLM-5.1 are Standard-API only; GLM-4.7, GLM-5.2, and GLM-4.5 Air work on both. To force-add any model (including new or proxy-hosted ones), use the [`glm-copilot.customModels`](#settings) setting.
 
 ### Does agent mode, tool calling, and MCP work?
 

--- a/docs/glm-api.md
+++ b/docs/glm-api.md
@@ -55,6 +55,22 @@ Top-level request field, binary:
 Enabled by default. In this extension, the `glm-copilot.thinking` setting maps
 directly to `thinking.type` on every request.
 
+### Reasoning effort
+
+GLM-5.2 also accepts a top-level `reasoning_effort` string that tunes how much the
+model reasons. It only takes effect when thinking is enabled and is GLM-5.2 only.
+
+```json
+{ "reasoning_effort": "max" }
+```
+
+Accepted values are `max` (the API default), `xhigh`, `high`, `medium`, `low`,
+`minimal`, and `none`. The API folds `low`/`medium` into `high` and `xhigh` into
+`max`; `none` and `minimal` skip thinking entirely. The extension surfaces three of
+these — `none` / `high` / `max` — through the Copilot model picker: `none` sends
+`thinking: { type: "disabled" }` with no `reasoning_effort`, while `high` and `max`
+send `thinking: { type: "enabled" }` plus the matching `reasoning_effort`.
+
 ## Tools
 
 OpenAI function-calling format:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "GLM for Copilot Chat",
 	"description": "Bring GLM (Z.ai / Zhipu) models into GitHub Copilot Chat with visible thinking. Coding Plan or Standard API.",
 	"icon": "resources/icon.png",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"publisher": "QiYijiazhen",
 	"license": "MIT",
 	"repository": {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,4 +1,4 @@
-import type { GLMModel } from './types';
+import type { GLMModel, ThinkingEffortSpec } from './types';
 
 /**
  * Compile-time constants shared across the extension. These do not depend on
@@ -49,6 +49,8 @@ export const URI_PATHS = {
 	showLogs: '/showLogs',
 } as const;
 
+const GLM_5_2_EFFORT: ThinkingEffortSpec = { levels: ['none', 'high', 'max'], default: 'high' };
+
 /** Built-in GLM models exposed through the language model provider. */
 export const MODELS: GLMModel[] = [
 	{
@@ -89,11 +91,16 @@ export const MODELS: GLMModel[] = [
 		name: 'GLM-5.2',
 		family: 'glm',
 		version: '5.2',
-		detail: 'Top Coding Plan model',
-		maxInputTokens: 200000,
+		detail: 'Flagship coding model, 1M context',
+		maxInputTokens: 1000000,
 		maxOutputTokens: 128000,
-		capabilities: { toolCalling: DEFAULT_TOOLS_LIMIT, imageInput: false, thinking: true },
-		availableIn: ['coding-plan'],
+		capabilities: {
+			toolCalling: DEFAULT_TOOLS_LIMIT,
+			imageInput: false,
+			thinking: true,
+			thinkingEffort: GLM_5_2_EFFORT,
+		},
+		availableIn: ['coding-plan', 'standard'],
 	},
 	{
 		id: 'glm-4.5-air',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -10,8 +10,9 @@ const en: Record<string, string> = {
 	'model.glm-5.tooltip': 'GLM-5 — 200K context, advanced reasoning and coding. Standard API only.',
 	'model.glm-5.1.detail': 'Latest GLM-5 series flagship',
 	'model.glm-5.1.tooltip': 'GLM-5.1 — latest GLM-5 series, 200K context. Standard API only.',
-	'model.glm-5.2.detail': 'Top Coding Plan model',
-	'model.glm-5.2.tooltip': 'GLM-5.2 — top GLM model on the Coding Plan, 200K context. Coding Plan only.',
+	'model.glm-5.2.detail': 'Flagship coding model, 1M context',
+	'model.glm-5.2.tooltip':
+		'GLM-5.2 — flagship GLM coding model, 1M context, selectable thinking effort. Available on Coding Plan and Standard API.',
 	'model.glm-4.5-air.detail': 'Fast and economical',
 	'model.glm-4.5-air.tooltip': 'GLM-4.5 Air — lightweight, fast, and low-cost. Available on both plans.',
 	'model.custom.detail': 'Custom model',
@@ -32,6 +33,15 @@ const en: Record<string, string> = {
 	'thinking.off': 'Off',
 	'thinking.on.desc': 'Enable step-by-step reasoning (recommended)',
 	'thinking.off.desc': 'Disable reasoning for faster responses',
+
+	// Thinking effort control
+	'effort.title': 'Thinking Effort',
+	'effort.none.label': 'None',
+	'effort.none.desc': 'No reasoning — fastest, lowest quota',
+	'effort.high.label': 'High',
+	'effort.high.desc': 'Balanced reasoning (recommended)',
+	'effort.max.label': 'Max',
+	'effort.max.desc': 'Deepest reasoning — best for hard coding, uses more quota',
 
 	// Request limits
 	'request.toolsLimitExceeded':
@@ -89,8 +99,8 @@ const zh: Record<string, string> = {
 	'model.glm-5.tooltip': 'GLM-5 — 20 万上下文，先进的推理与编程。仅标准 API 可用。',
 	'model.glm-5.1.detail': '最新 GLM-5 系列旗舰',
 	'model.glm-5.1.tooltip': 'GLM-5.1 — 最新 GLM-5 系列，20 万上下文。仅标准 API 可用。',
-	'model.glm-5.2.detail': '编程计划顶级模型',
-	'model.glm-5.2.tooltip': 'GLM-5.2 — 编程计划中的顶级 GLM 模型，20 万上下文。仅编程计划可用。',
+	'model.glm-5.2.detail': '旗舰编程模型，100 万上下文',
+	'model.glm-5.2.tooltip': 'GLM-5.2 — 旗舰 GLM 编程模型，100 万上下文，可选思考强度。编程计划和标准 API 均可用。',
 	'model.glm-4.5-air.detail': '快速且经济',
 	'model.glm-4.5-air.tooltip': 'GLM-4.5 Air — 轻量、快速、低成本。两种计划均可用。',
 	'model.custom.detail': '自定义模型',
@@ -108,6 +118,14 @@ const zh: Record<string, string> = {
 	'thinking.off': '关闭',
 	'thinking.on.desc': '启用逐步推理（推荐）',
 	'thinking.off.desc': '关闭推理以获得更快响应',
+
+	'effort.title': '思考强度',
+	'effort.none.label': '关闭',
+	'effort.none.desc': '不进行推理——最快、消耗最低',
+	'effort.high.label': '高',
+	'effort.high.desc': '均衡推理（推荐）',
+	'effort.max.label': '最高',
+	'effort.max.desc': '最深入的推理——适合复杂编程，消耗更多额度',
 
 	'request.toolsLimitExceeded':
 		'GLM 单次请求最多支持 {0} 个工具，但本次请求包含 {1} 个。请使用 VS Code 的“配置工具”关闭不常用的工具。',

--- a/src/provider/models.ts
+++ b/src/provider/models.ts
@@ -1,11 +1,33 @@
 import * as vscode from 'vscode';
 import { t } from '../i18n';
-import type { GLMModel } from '../types';
+import type { GLMModel, ThinkingEffortSpec } from '../types';
+
+function buildEffortSchema(spec: ThinkingEffortSpec) {
+	return {
+		properties: {
+			reasoningEffort: {
+				type: 'string',
+				title: t('effort.title'),
+				enum: spec.levels,
+				enumItemLabels: spec.levels.map((level) => t(`effort.${level}.label`)),
+				enumDescriptions: spec.levels.map((level) => t(`effort.${level}.desc`)),
+				default: spec.default,
+				group: 'navigation',
+			},
+		},
+	} as const;
+}
+
+/** Non-public `configurationSchema` field the Copilot host reads at runtime (intersection type). */
+type EffortChatInformation = vscode.LanguageModelChatInformation & {
+	readonly configurationSchema?: ReturnType<typeof buildEffortSchema>;
+};
 
 /** Build the Copilot Chat model picker entry for a GLM model. */
-export function toChatInfo(model: GLMModel, hasApiKey: boolean): vscode.LanguageModelChatInformation {
+export function toChatInfo(model: GLMModel, hasApiKey: boolean): EffortChatInformation {
 	const detail = resolveModelText(model, 'detail') ?? model.detail;
 	const tooltip = resolveModelText(model, 'tooltip');
+	const spec = model.capabilities.thinkingEffort;
 	return {
 		id: model.id,
 		name: model.name,
@@ -19,6 +41,7 @@ export function toChatInfo(model: GLMModel, hasApiKey: boolean): vscode.Language
 			toolCalling: model.capabilities.toolCalling,
 			imageInput: model.capabilities.imageInput,
 		},
+		...(spec ? { configurationSchema: buildEffortSchema(spec) } : {}),
 	};
 }
 

--- a/src/provider/request.ts
+++ b/src/provider/request.ts
@@ -4,7 +4,14 @@ import { findModelDefinition, getApiModelId, getMaxTokens, getThinking } from '.
 import { DEFAULT_TOOLS_LIMIT } from '../consts';
 import { resolveBaseUrl } from '../endpoint';
 import { t } from '../i18n';
-import type { GLMChatRequest, GLMTool, IAuthManager, ThinkingMode } from '../types';
+import type {
+	GLMChatRequest,
+	GLMTool,
+	IAuthManager,
+	ThinkingEffort,
+	ThinkingEffortSpec,
+	ThinkingMode,
+} from '../types';
 import { convertMessages, convertTools, countMessageChars } from './convert';
 
 interface PrepareChatRequestArgs {
@@ -45,6 +52,17 @@ export async function prepareChatRequest({
 		throw new Error(t('request.toolsLimitExceeded', String(toolLimit), String(tools.length)));
 	}
 	const hasTools = !!(tools && tools.length > 0);
+	const effortSpec = modelDef?.capabilities.thinkingEffort;
+	let thinkingFields: Pick<GLMChatRequest, 'thinking' | 'reasoning_effort'> = {};
+	if (effortSpec) {
+		const effort = resolveEffort(options as EffortOptions, effortSpec);
+		thinkingFields =
+			effort === 'none'
+				? { thinking: { type: 'disabled' } }
+				: { thinking: { type: 'enabled' }, reasoning_effort: effort };
+	} else if (isThinkingModel) {
+		thinkingFields = { thinking: { type: resolveThinking(options) } };
+	}
 	const request: GLMChatRequest = {
 		model: getApiModelId(modelInfo.id),
 		messages: glmMessages,
@@ -52,10 +70,20 @@ export async function prepareChatRequest({
 		tools: hasTools ? tools : undefined,
 		tool_choice: hasTools ? 'auto' : undefined,
 		max_tokens: getMaxTokens(),
-		...(isThinkingModel ? { thinking: { type: resolveThinking(options) } } : {}),
+		...thinkingFields,
 	};
 	const totalRequestChars = countMessageChars(glmMessages);
 	return { client, request, totalRequestChars, isThinkingModel };
+}
+
+type EffortOptions = vscode.ProvideLanguageModelChatResponseOptions & {
+	readonly modelConfiguration?: { readonly reasoningEffort?: ThinkingEffort };
+	readonly configuration?: { readonly reasoningEffort?: ThinkingEffort };
+};
+
+function resolveEffort(options: EffortOptions, spec: ThinkingEffortSpec): ThinkingEffort {
+	const picked = options.modelConfiguration?.reasoningEffort ?? options.configuration?.reasoningEffort;
+	return picked && spec.levels.includes(picked) ? picked : spec.default;
 }
 
 /** Thinking mode from a per-request override (modelOptions), else the setting. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,11 +4,22 @@ export type ThinkingMode = 'enabled' | 'disabled';
 export type ApiMode = 'coding-plan' | 'standard';
 export type Region = 'international' | 'china';
 
+export type ThinkingEffort = 'none' | 'high' | 'max';
+
+export interface ThinkingEffortSpec {
+	/** Levels shown in the picker, in order. */
+	levels: ThinkingEffort[];
+	/** Level used when the user has not chosen one. */
+	default: ThinkingEffort;
+}
+
 export interface GLMModelCapabilities {
 	/** `true` enables tool calling with the default cap; a number sets a custom cap. */
 	toolCalling: number | boolean;
 	imageInput: boolean;
 	thinking: boolean;
+	/** Present ⇒ model supports thinking-effort selection. Absent ⇒ binary thinking only. */
+	thinkingEffort?: ThinkingEffortSpec;
 }
 
 /** A GLM model exposed in the Copilot Chat picker. */
@@ -71,6 +82,7 @@ export interface GLMChatRequest {
 	tool_choice?: 'auto' | 'none';
 	max_tokens?: number;
 	thinking?: { type: ThinkingMode };
+	reasoning_effort?: Exclude<ThinkingEffort, 'none'>;
 	stream_options?: { include_usage: boolean };
 }
 


### PR DESCRIPTION
## Summary

Adds the GLM-5.2 **Thinking Effort** picker and updates GLM-5.2 metadata to match the current z.ai docs, for release **v0.2.2**.

- **Thinking Effort picker (GLM-5.2):** a native per-model control in the Copilot model picker with levels **None / High / Max** (default **High**), via the publishable `configurationSchema` intersection-type pattern (`enabledApiProposals: []`, no `as any`). It maps to GLM-5.2's top-level `reasoning_effort` on the wire (`none` → thinking disabled; `high`/`max` → thinking enabled + effort) and **owns** thinking for GLM-5.2, so it never conflicts with the global `glm-copilot.thinking` toggle.
- **GLM-5.2 metadata:** context window **1M**; now offered on the **Standard API** as well as the Coding Plan.
- **Packaging hygiene:** `.vscodeignore` now excludes `.claude/**` — the published 0.2.1 VSIX bundled `.claude/settings.local.json`.
- Docs (`README.md`, `docs/glm-api.md`, `CHANGELOG.md`) and `version` → `0.2.2`.

## Caveat

**GLM-5.2 Standard availability is unverified on the wire.** The docs list it on the standard pricing page and its model page uses `/api/paas/v4`, so `availableIn` includes `standard` — but this wasn't confirmed with a live Standard-key request. If the docs are ahead of rollout, GLM-5.2 would 404 in Standard mode; revert `availableIn` to coding-plan-only if so.

## Checks

`pnpm exec tsc -p ./ --noEmit` clean; `pnpm exec vsce package --no-dependencies` clean (38 files, no leaked local files).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-model "Thinking Effort" picker for GLM-5.2 (None/High/Max) with persistent selection per model.
  * GLM-5.2 now available on Standard API in addition to Coding Plan.

* **Enhancements**
  * Increased GLM-5.2 context window to 1M tokens.

* **Documentation**
  * Updated documentation to reflect new thinking effort configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->