### PR TITLE
chore: update marketplace publisher to YijiazhenQi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GLM for Copilot Chat
 
-[![VS Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/QiYijiazhen.glm-for-copilot?label=Marketplace&color=1f6feb)](https://marketplace.visualstudio.com/items?itemName=QiYijiazhen.glm-for-copilot)
-[![Installs](https://img.shields.io/visual-studio-marketplace/i/QiYijiazhen.glm-for-copilot?label=Installs)](https://marketplace.visualstudio.com/items?itemName=QiYijiazhen.glm-for-copilot)
+[![VS Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/YijiazhenQi.glm-for-copilot?label=Marketplace&color=1f6feb)](https://marketplace.visualstudio.com/items?itemName=YijiazhenQi.glm-for-copilot)
+[![Installs](https://img.shields.io/visual-studio-marketplace/i/YijiazhenQi.glm-for-copilot?label=Installs)](https://marketplace.visualstudio.com/items?itemName=YijiazhenQi.glm-for-copilot)
 [![CI](https://github.com/KiwiGaze/glm-for-copilot/actions/workflows/ci.yml/badge.svg)](https://github.com/KiwiGaze/glm-for-copilot/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.txt)
 
@@ -65,10 +65,10 @@ Because this extension plugs into Copilot's native Language Model Provider API, 
 
 ### Installation
 
-Install from the **[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=QiYijiazhen.glm-for-copilot)**, or search for **"GLM for Copilot Chat"** in the Extensions panel (`Cmd/Ctrl + Shift + X`). From the command line:
+Install from the **[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=YijiazhenQi.glm-for-copilot)**, or search for **"GLM for Copilot Chat"** in the Extensions panel (`Cmd/Ctrl + Shift + X`). From the command line:
 
 ```bash
-code --install-extension QiYijiazhen.glm-for-copilot
+code --install-extension YijiazhenQi.glm-for-copilot
 ```
 
 ### Usage

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@
 
 Key facts:
 
-- **Type:** VS Code extension (Marketplace), published under the `glm-copilot` publisher.
+- **Type:** VS Code extension (Marketplace), published under the `YijiazhenQi` publisher.
 - **What it does:** lets you use GLM models inside GitHub Copilot Chat without replacing Copilot's UI.
 - **How it works:** implements `vscode.LanguageModelChatProvider`; streams OpenAI-compatible SSE from the GLM API.
 - **Dual API:** choose your **GLM Coding Plan** subscription or the pay-as-you-go **Standard API** — each available International (`z.ai`) or Mainland China (`bigmodel.cn`).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Bring GLM (Z.ai / Zhipu) models into GitHub Copilot Chat with visible thinking. Coding Plan or Standard API.",
 	"icon": "resources/icon.png",
 	"version": "0.2.2",
-	"publisher": "QiYijiazhen",
+	"publisher": "YijiazhenQi",
 	"license": "MIT",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## What

Update the VS Code Marketplace publisher from `QiYijiazhen` to `YijiazhenQi`.

- `package.json` — the `publisher` field (the value `vsce` uses when publishing)
- `README.md` — Marketplace version/installs badges and the `code --install-extension` command
- `llms.txt` — publisher note (also corrects a pre-existing error: it named the command prefix `glm-copilot` as the publisher)

## Why

The previous publisher account `QiYijiazhen` was blocked, so the extension must be published under a new account.

## Impact

The extension's full Marketplace identifier changes from `QiYijiazhen.glm-for-copilot` to `YijiazhenQi.glm-for-copilot`. The Marketplace treats this as a **new listing** — new URL, install count starts at zero, and existing users will not auto-update from the old (blocked) listing.

## Verification

- `tsc -p ./ --noEmit` — passes
- `vsce package --no-dependencies` — packages successfully with the new publisher


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated marketplace publisher identifier and configuration for the "GLM for Copilot Chat" extension to ensure consistent identification across distribution channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->