### PR TITLE
Refactor marketplace identity metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,21 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: deps
+    ignore:
+      # @types/node must track engines.node (currently >= 20).
+      # Ignore major bumps so types can't drift ahead of the declared runtime.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      # Type-only dev dependency; bumps aren't worth the PR noise.
+      - dependency-name: "@types/vscode"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     commit-message:
       prefix: ci
+    ignore:
+      # Actions majors often carry breaking changes (e.g. checkout v7 fork-PR handling).
+      # Take those deliberately instead of automatically.
+      - dependency-name: "actions/checkout"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,10 @@ updates:
       # Ignore major bumps so types can't drift ahead of the declared runtime.
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
-      # Type-only dev dependency; bumps aren't worth the PR noise.
+      # Type-only dev dependency; ignore major bumps so types track the
+      # declared API surface (engines.vscode ^1.116.0) without PR noise.
       - dependency-name: "@types/vscode"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
         run: pnpm exec tsc -p ./ --noEmit
 
       - name: Package extension
-        run: pnpm exec vsce package --no-dependencies -o glm-for-copilot-chat.vsix
+        run: pnpm exec vsce package --no-dependencies -o glm-for-github-copilot-chat.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           fi
 
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "asset=dist/glm-for-copilot-chat-${VERSION}.vsix" >> "$GITHUB_OUTPUT"
+          echo "asset=dist/glm-for-github-copilot-chat-${VERSION}.vsix" >> "$GITHUB_OUTPUT"
 
       - name: Typecheck
         run: pnpm exec tsc -p ./ --noEmit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-All notable changes to GLM for GitHub Copilot Chat are documented here.
+All notable changes to GLM Models for GitHub Copilot Chat are documented here.
+
+## 0.2.5
+
+- **Marketplace identity** - moved the extension package to `yijiazhen-qi.glm-for-github-copilot-chat` and updated install links, package metadata, and release artifact names.
+- **Display name** - changed the visible Marketplace name to `GLM Models for GitHub Copilot Chat`.
+- **Migration note** - documented uninstalling the old `YijiazhenQi.glm-for-copilot-chat` listing before installing the new one.
+- **Docs cleanup** - aligned the settings title with the product name, refreshed the walkthrough model examples, and removed a stale project-plan reference from the contributing guide.
 
 ## 0.2.4
 
@@ -9,7 +16,7 @@ All notable changes to GLM for GitHub Copilot Chat are documented here.
 ## 0.2.3
 
 - **Mainland China Coding Plan** — `region: china` now routes Coding Plan requests to `open.bigmodel.cn/api/coding/paas/v4` instead of z.ai, and `GLM: Get API Key` opens the bigmodel.cn coding-plan console. International Coding Plan and all Standard endpoints are unchanged; `region` defaults to `international`, so existing users are unaffected.
-- **Renamed to "GLM for GitHub Copilot Chat"** — updated the extension's marketplace display name. No functional changes.
+- **Display name update** — clarified the extension's GitHub Copilot Chat integration in the Marketplace name. No functional changes.
 
 ## 0.2.2
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Our pledge
 
-We want taking part in the GLM for GitHub Copilot Chat project to be a welcoming and respectful
+We want taking part in the GLM Models for GitHub Copilot Chat project to be a welcoming and respectful
 experience for everyone, regardless of background or identity.
 
 ## Our standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to GLM for GitHub Copilot Chat
+# Contributing to GLM Models for GitHub Copilot Chat
 
-Thanks for your interest in improving **GLM for GitHub Copilot Chat** — a VS Code extension that
+Thanks for your interest in improving **GLM Models for GitHub Copilot Chat** — a VS Code extension that
 brings GLM (Z.ai / Zhipu) models into the GitHub Copilot Chat model picker. Contributions of
 all kinds are welcome: bug reports, feature requests, documentation fixes, and code.
 
@@ -23,8 +23,7 @@ there.
 
 ## Project layout
 
-The implementation is plain TypeScript with **zero runtime dependencies**. The design and the
-full file map live in [`PLAN.md`](PLAN.md). At a glance:
+The implementation is plain TypeScript with **zero runtime dependencies**. Key directories:
 
 - `src/extension.ts` — activation entry point.
 - `src/client/` — OpenAI-compatible SSE streaming client for the GLM API.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 GLM for GitHub Copilot Chat contributors
+Copyright (c) 2026 GLM Models for GitHub Copilot Chat contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# GLM for GitHub Copilot Chat
+# GLM Models for GitHub Copilot Chat
 
-[![VS Marketplace Version](https://img.shields.io/badge/Marketplace-0.2.4-1f6feb)](https://marketplace.visualstudio.com/items?itemName=YijiazhenQi.glm-for-copilot-chat)
-[![Install from VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Install-007ACC)](https://marketplace.visualstudio.com/items?itemName=YijiazhenQi.glm-for-copilot-chat)
+[![VS Marketplace Version](https://img.shields.io/badge/Marketplace-0.2.5-1f6feb)](https://marketplace.visualstudio.com/items?itemName=yijiazhen-qi.glm-for-github-copilot-chat)
+[![Install from VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Install-007ACC)](https://marketplace.visualstudio.com/items?itemName=yijiazhen-qi.glm-for-github-copilot-chat)
 [![CI](https://github.com/KiwiGaze/glm-for-copilot/actions/workflows/ci.yml/badge.svg)](https://github.com/KiwiGaze/glm-for-copilot/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.txt)
 
@@ -65,10 +65,17 @@ Because this extension plugs into Copilot's native Language Model Provider API, 
 
 ### Installation
 
-Install from the **[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=YijiazhenQi.glm-for-copilot-chat)**, or search for **"GLM for GitHub Copilot Chat"** in the Extensions panel (`Cmd/Ctrl + Shift + X`). From the command line:
+Install from the **[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=yijiazhen-qi.glm-for-github-copilot-chat)**, or search for **"GLM Models for GitHub Copilot Chat"** in the Extensions panel (`Cmd/Ctrl + Shift + X`). From the command line:
 
 ```bash
-code --install-extension YijiazhenQi.glm-for-copilot-chat
+code --install-extension yijiazhen-qi.glm-for-github-copilot-chat
+```
+
+If you installed an older Marketplace listing, uninstall it before installing this one. The old and new extension IDs can both register the same `glm-copilot.*` commands and settings.
+
+```bash
+code --uninstall-extension YijiazhenQi.glm-for-copilot-chat
+code --install-extension yijiazhen-qi.glm-for-github-copilot-chat
 ```
 
 ### Usage
@@ -189,4 +196,4 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## License
 
-[MIT](LICENSE.txt) © GLM for GitHub Copilot Chat contributors
+[MIT](LICENSE.txt) © GLM Models for GitHub Copilot Chat contributors

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-The latest published version of **GLM for GitHub Copilot Chat** on the VS Code Marketplace receives
+The latest published version of **GLM Models for GitHub Copilot Chat** on the VS Code Marketplace receives
 security fixes. Please update to the newest version before reporting an issue.
 
 | Version | Supported |

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,6 +1,6 @@
 # Support
 
-Thanks for using **GLM for GitHub Copilot Chat**. Here is how to get help.
+Thanks for using **GLM Models for GitHub Copilot Chat**. Here is how to get help.
 
 ## Before you ask
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,4 +1,4 @@
-# GLM for GitHub Copilot Chat
+# GLM Models for GitHub Copilot Chat
 
 > A Visual Studio Code extension that adds GLM (Z.ai / Zhipu) models to the GitHub Copilot Chat
 > model picker using your own API key (BYOK). It registers GLM-4.7, GLM-5, GLM-5.1, GLM-5.2, and
@@ -8,7 +8,7 @@
 
 Key facts:
 
-- **Type:** VS Code extension (Marketplace), published under the `YijiazhenQi` publisher.
+- **Type:** VS Code extension (Marketplace), published as `yijiazhen-qi.glm-for-github-copilot-chat`.
 - **What it does:** lets you use GLM models inside GitHub Copilot Chat without replacing Copilot's UI.
 - **How it works:** implements `vscode.LanguageModelChatProvider`; streams OpenAI-compatible SSE from the GLM API.
 - **Dual API:** choose your **GLM Coding Plan** subscription or the pay-as-you-go **Standard API** — each available International (`z.ai`) or Mainland China (`bigmodel.cn`).
@@ -23,7 +23,7 @@ Key facts:
 - [Models and settings](README.md#models): which GLM models are available per API mode, and all configuration options.
 - [Coding Plan vs Standard API](README.md#coding-plan-vs-standard-api): endpoint routing and when to use each.
 - [Changelog](CHANGELOG.md): release history.
-- [Implementation plan](PLAN.md): architecture, file map, and design decisions.
+- [Contributing guide](CONTRIBUTING.md): project layout, setup, and development conventions.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-	"name": "glm-for-copilot-chat",
-	"displayName": "GLM for GitHub Copilot Chat",
+	"name": "glm-for-github-copilot-chat",
+	"displayName": "GLM Models for GitHub Copilot Chat",
 	"description": "Bring GLM (Z.ai / Zhipu) models into GitHub Copilot Chat with visible thinking. Coding Plan or Standard API.",
 	"icon": "resources/icon.png",
-	"version": "0.2.4",
-	"publisher": "YijiazhenQi",
+	"version": "0.2.5",
+	"publisher": "yijiazhen-qi",
 	"license": "MIT",
 	"repository": {
 		"type": "git",

--- a/package.nls.json
+++ b/package.nls.json
@@ -5,7 +5,7 @@
   "glm-copilot.command.openSettings": "GLM: Open Settings",
   "glm-copilot.command.showLogs": "GLM: Show Logs",
 
-  "glm-copilot.walkthrough.title": "GLM for GitHub Copilot Chat",
+  "glm-copilot.walkthrough.title": "GLM Models for GitHub Copilot Chat",
   "glm-copilot.walkthrough.description": "Set up GLM models in GitHub Copilot Chat.",
 
   "glm-copilot.walkthrough.setApiKey.title": "Set your GLM API key",
@@ -17,7 +17,7 @@
   "glm-copilot.walkthrough.showModels.title": "Show GLM models in the picker",
   "glm-copilot.walkthrough.showModels.description": "Your GLM models appear in the Copilot Chat model picker, filtered by your selected API Mode. If they are hidden, open the Language Models manager to show them.\n[Open Language Models](command:workbench.action.chat.manage)",
 
-  "glm-copilot.config.title": "GLM Copilot",
+  "glm-copilot.config.title": "GLM Models for GitHub Copilot Chat",
 
   "glm-copilot.config.apiMode.description": "Which GLM API to use.\n\n- **Coding Plan** — uses your GLM Coding Plan subscription ([Z.ai](https://z.ai/manage-apikey/subscription) International or [bigmodel.cn](https://bigmodel.cn/coding-plan/personal/overview) Mainland China). The active endpoint depends on the `region` setting. Best for teams or heavy coding use.\n- **Standard API** — pay-as-you-go access via the GLM Open Platform. The active endpoint depends on the `region` setting.",
   "glm-copilot.config.apiMode.codingPlan.label": "Coding Plan",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -5,7 +5,7 @@
   "glm-copilot.command.openSettings": "GLM: 打开设置",
   "glm-copilot.command.showLogs": "GLM: 显示日志",
 
-  "glm-copilot.walkthrough.title": "GLM for GitHub Copilot Chat",
+  "glm-copilot.walkthrough.title": "GLM Models for GitHub Copilot Chat",
   "glm-copilot.walkthrough.description": "在 GitHub Copilot Chat 中使用 GLM 模型。",
 
   "glm-copilot.walkthrough.setApiKey.title": "设置 GLM API 密钥",
@@ -17,7 +17,7 @@
   "glm-copilot.walkthrough.showModels.title": "在选择器中查看 GLM 模型",
   "glm-copilot.walkthrough.showModels.description": "你的 GLM 模型将根据所选的 API 模式出现在 Copilot Chat 的模型选择器中。如果看不到，请打开语言模型管理器以显示它们。\n[打开语言模型](command:workbench.action.chat.manage)",
 
-  "glm-copilot.config.title": "GLM Copilot",
+  "glm-copilot.config.title": "GLM Models for GitHub Copilot Chat",
 
   "glm-copilot.config.apiMode.description": "选择要使用的 GLM API。\n\n- **编程计划** — 使用您的 GLM 编程计划订阅（[Z.ai](https://z.ai/manage-apikey/subscription) 国际版或 [bigmodel.cn](https://bigmodel.cn/coding-plan/personal/overview) 中国大陆）。实际端点取决于 `region` 设置，适合团队或高频编码场景。\n- **标准 API** — 按量付费，通过 GLM 开放平台访问，实际端点取决于 `region` 设置。",
   "glm-copilot.config.apiMode.codingPlan.label": "编程计划",

--- a/resources/walkthrough/set-api-key.md
+++ b/resources/walkthrough/set-api-key.md
@@ -1,4 +1,4 @@
-GLM for GitHub Copilot Chat uses your own GLM API key to make GLM models available in the Copilot model picker.
+GLM Models for GitHub Copilot Chat uses your own GLM API key to make GLM models available in the Copilot model picker.
 
 Your key is stored in VS Code's SecretStorage (the OS keychain). It is never written to `settings.json` or your Git history.
 

--- a/resources/walkthrough/show-models.md
+++ b/resources/walkthrough/show-models.md
@@ -1,4 +1,4 @@
-Your GLM models appear in the Copilot Chat model picker as soon as the extension is active. The picker shows only the models available for your selected **API Mode** — for example GLM-4.7, GLM-5.2, and GLM-4.5 Air on the Coding Plan, or GLM-4.7, GLM-5, GLM-5.1, and GLM-4.5 Air on the Standard API.
+Your GLM models appear in the Copilot Chat model picker as soon as the extension is active. The picker shows only the models available for your selected **API Mode** — for example GLM-4.7, GLM-5.2, and GLM-4.5 Air on the Coding Plan, or GLM-4.7, GLM-5, GLM-5.1, GLM-5.2, and GLM-4.5 Air on the Standard API.
 
 Until you run `GLM: Set API Key`, the models appear with a reminder to set your key. If you do not see them right away, the model list may be long — scroll down and look for the GLM models.
 

--- a/src/runtime/lifecycle.ts
+++ b/src/runtime/lifecycle.ts
@@ -11,7 +11,7 @@ let activeProvider: GLMChatProvider | undefined;
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 	try {
-		logger.info('Activating GLM for GitHub Copilot Chat');
+		logger.info('Activating GLM Models for GitHub Copilot Chat');
 		registerCommands(context);
 		registerActionUrls(context);
 		activeProvider = await registerProvider(context);


### PR DESCRIPTION
## Summary
- move the Marketplace package identity to `yijiazhen-qi.glm-for-github-copilot-chat` at version `0.2.5`
- change the visible Marketplace display name to `GLM Models for GitHub Copilot Chat` after the previous display name was rejected as taken
- update install links, migration notes, release artifact names, docs, walkthrough copy, and Dependabot ignore rules

## Validation
- `pnpm exec tsc -p ./ --noEmit`
- `pnpm exec vsce package --no-dependencies -o dist/glm-for-github-copilot-chat-0.2.5.vsix`
- inspected the VSIX manifest for publisher/name/version/displayName
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GLM-5.2 to the Copilot Chat model picker examples.

* **Chores**
  * Rebranded the extension to **“GLM Models for GitHub Copilot Chat”** and updated the Marketplace identity/display name.
  * Updated installation and migration guidance for the new extension ID (including uninstall-first advice).
  * Refreshed UI text and documentation (including security/support) to match the updated branding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->