### PR TITLE
feat: configurable retry limit for chat requests (maxRetries)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to GLM Models for GitHub Copilot Chat are documented here.
 
+## 0.2.8
+
+- **Configurable retry limit** - new `glm-copilot.maxRetries` setting (0–10) caps automatic retries for transient chat failures (HTTP 429 and 5xx). Set `0` to disable automatic retries and fail fast when rate limited. The default drops from 9 retries (10 total attempts) to 3 (4 total attempts), so peak-hour throttling no longer holds a request through ~1.5 minutes of backoff by default. (#20)
+
 ## 0.2.7
 
 - **Retry with exponential backoff** - chat requests now retry transient GLM API failures (HTTP 429 and 5xx) with exponential backoff and jitter before any output is streamed, honoring the server's `Retry-After` / `retry-after-ms` header when present. Up to 10 total attempts, 1s base delay, 10s cap. This clears rate-limit windows instead of failing fast, so the same API key that works in other GLM clients no longer surfaces "HTTP 429 Too many requests" in Copilot Chat. Non-retryable errors (4xx) and exhausted retries still surface the existing user-facing error. Cancellation during a backoff wait aborts promptly.

--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@
   <img src="docs/glm-composer-light.png" alt="GLM-5.2 selected in the Copilot Chat composer in light theme, with Thinking Effort set to Max" width="420">
 </p>
 
-Use your own GLM API key (BYOK) to bring Z.AI's GLM models into GitHub Copilot Chat — **GLM-5.2**, the 1M-context flagship built for long-horizon coding, plus a curated GLM lineup (GLM-5.1, GLM-5, GLM-4.7, GLM-4.5 Air). No new sidebar or chat UI: the models appear in the picker you already use, with agent mode, tool calling, and thinking mode available through Copilot's native provider path.
+Bring Z.AI's GLM models into GitHub Copilot Chat with your own API key (BYOK) — **GLM-5.2**, the 1M-context flagship built for long-horizon coding, plus a curated lineup (GLM-5.1, GLM-5, GLM-4.7, GLM-4.5 Air). No new sidebar or chat UI: the models appear in the picker you already use, with agent mode, tool calling, and thinking through Copilot's native provider path.
 
 > **Unofficial, community-built extension.** Not affiliated with, endorsed by, or sponsored by Zhipu AI, Z.AI, GitHub, or Microsoft. "GLM", "Copilot", and "Visual Studio Code" are trademarks of their respective owners. You bring your own GLM API key and pay your own usage.
 
 ## Features
 
-- **GLM-5.2 flagship, right in the picker.** A 1M-token context window, step-by-step thinking that streams live into the chat, and a per-model **Thinking Effort** control (None / High / Max). Choose None for faster simple edits. Switch models mid-chat without losing history.
+- **GLM-5.2 flagship, right in the picker.** A 1M-token context window, step-by-step thinking that streams live into Copilot's native thinking UI, and a per-model **Thinking Effort** control (None / High / Max) — pick None for faster simple edits. Switch models mid-chat without losing history.
 
-- **Powers Copilot up, doesn't replace it.** GLM models appear alongside GPT and Claude. Because the extension plugs into Copilot's native Language Model Provider API, Copilot agent mode and tool calling continue through the normal chat experience.
+- **Powers Copilot up, doesn't replace it.** GLM models appear alongside GPT and Claude. Because the extension uses Copilot's native Language Model Provider API, agent mode and tool calling keep working as usual.
 - **Dual API.** Use your **GLM Coding Plan** subscription or the pay-as-you-go **Standard API** — each available International (`z.ai`) or Mainland China (`bigmodel.cn`). See [Coding Plan vs Standard API](#coding-plan-vs-standard-api).
-- **Live Coding Plan usage.** A status-bar quota readout, **GLM: Refresh Usage** on demand, and a full **GLM: Show Usage Details** panel — session (5-hour) and weekly (7-day) limits, monthly web searches, and reset countdowns. Refreshes automatically; the status-bar item can be hidden. Coding Plan, International region, no `baseUrl` override.
+- **Live Coding Plan usage.** A status-bar quota readout plus a full **GLM: Show Usage Details** panel — session (5-hour) and weekly (7-day) limits, monthly web searches, and reset countdowns. Refreshes automatically; the status-bar item can be hidden. Coding Plan, International region, no `baseUrl` override.
 
 <p align="center">
   <img src="docs/glm-usage-panel.png" alt="GLM Usage panel showing session, weekly, and web-search quota with reset countdowns for a GLM Coding plan" width="760">
@@ -70,7 +70,7 @@ Use **GLM: Set API Key** or **GLM: Clear API Key** to update or remove the key l
 | **GLM-4.7** | Fast coding | 200K | 128K | Coding Plan + Standard | Yes | Yes |
 | **GLM-4.5 Air** | Lightweight | 128K | 96K | Coding Plan + Standard | Yes | Yes |
 
-The picker shows only the models your selected **API Mode** can serve, so you never pick a model your plan can't use. GLM-5.2, GLM-4.7, and GLM-4.5 Air work on both; GLM-5 and GLM-5.1 are Standard-only. Need a model not listed — a newly released one like GLM-5-Turbo, an older one like GLM-4.6, or a proxy-hosted id? Add it with [`glm-copilot.customModels`](#settings).
+The picker shows only the models your selected **API Mode** can serve, so you never pick one your plan can't use. GLM-5.2, GLM-4.7, and GLM-4.5 Air work on both; GLM-5 and GLM-5.1 are Standard-only. Need a model not listed — newer (GLM-5-Turbo), older (GLM-4.6), or proxy-hosted? Add it with [`glm-copilot.customModels`](#settings).
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GLM Models for GitHub Copilot Chat
 
-[![VS Marketplace Version](https://img.shields.io/badge/Marketplace-0.2.7-1f6feb)](https://marketplace.visualstudio.com/items?itemName=yijiazhen-qi.glm-for-github-copilot-chat)
+[![VS Marketplace Version](https://img.shields.io/badge/Marketplace-0.2.8-1f6feb)](https://marketplace.visualstudio.com/items?itemName=yijiazhen-qi.glm-for-github-copilot-chat)
 [![Install from VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Install-007ACC)](https://marketplace.visualstudio.com/items?itemName=yijiazhen-qi.glm-for-github-copilot-chat)
 [![CI](https://github.com/KiwiGaze/glm-for-copilot/actions/workflows/ci.yml/badge.svg)](https://github.com/KiwiGaze/glm-for-copilot/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.txt)
@@ -80,6 +80,7 @@ The picker shows only the models your selected **API Mode** can serve, so you ne
 | `glm-copilot.region` | `international` | Server region for **both** API modes: `international` (z.ai) or `china` (bigmodel.cn). Ignored only when `baseUrl` is set. |
 | `glm-copilot.baseUrl` | *(empty)* | Override the API base URL. Overrides `apiMode` and `region`. Use for proxies or compatible APIs. |
 | `glm-copilot.maxTokens` | `0` | Maximum output tokens per request. `0` means no explicit limit (uses API default). |
+| `glm-copilot.maxRetries` | `3` | Automatic retries for transient chat failures (HTTP `429`/`5xx`), not counting the first attempt. `0` disables retries (fail fast). Range 0–10. Backoff honors the server's `Retry-After`. |
 | `glm-copilot.thinking` | `enabled` | Step-by-step reasoning: `enabled` (higher quality) or `disabled` (faster). Applies to thinking-capable models without a per-model Thinking Effort picker; GLM-5.2 uses None / High / Max in the model picker. |
 | `glm-copilot.customModels` | `[]` | Add your own models. Array of model id strings or objects: `{ id, name?, maxInputTokens?, maxOutputTokens?, toolCalling?, vision?, thinking? }`. |
 | `glm-copilot.modelIdOverrides` | `{}` | Remap a built-in model's API id (keys = picker id, values = id sent to the API). Use for regional endpoints or proxies with different names. |

--- a/docs/glm-api.md
+++ b/docs/glm-api.md
@@ -42,7 +42,7 @@ Streaming is OpenAI-compatible server-sent events:
 - Reasoning/thinking deltas: `choices[0].delta.reasoning_content`.
 - Tool-call deltas: `choices[0].delta.tool_calls[]`.
 - Usage: top-level `usage` object, emitted in the final streaming chunk before
-  `data: [DONE]` (no opt-in flag required).
+  `data: [DONE]`. The extension opts in with `stream_options: { include_usage: true }`.
 
 ## Thinking mode
 

--- a/docs/glm-api.md
+++ b/docs/glm-api.md
@@ -41,8 +41,8 @@ Streaming is OpenAI-compatible server-sent events:
 - Text deltas: `choices[0].delta.content`.
 - Reasoning/thinking deltas: `choices[0].delta.reasoning_content`.
 - Tool-call deltas: `choices[0].delta.tool_calls[]`.
-- Usage: top-level `usage` object. Request it with
-  `stream_options: { include_usage: true }`.
+- Usage: top-level `usage` object, emitted in the final streaming chunk before
+  `data: [DONE]` (no opt-in flag required).
 
 ## Thinking mode
 

--- a/package.json
+++ b/package.json
@@ -165,6 +165,13 @@
 					"minimum": 0,
 					"description": "%glm-copilot.config.maxTokens.description%"
 				},
+				"glm-copilot.maxRetries": {
+					"type": "integer",
+					"default": 3,
+					"minimum": 0,
+					"maximum": 10,
+					"markdownDescription": "%glm-copilot.config.maxRetries.description%"
+				},
 				"glm-copilot.modelIdOverrides": {
 					"type": "object",
 					"default": {},

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "GLM Models for GitHub Copilot Chat",
 	"description": "Bring GLM-5.2 and the full GLM lineup (Z.ai / Zhipu) into GitHub Copilot Chat with visible thinking. Coding Plan or Standard API.",
 	"icon": "resources/icon.png",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"publisher": "yijiazhen-qi",
 	"license": "MIT",
 	"repository": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -35,6 +35,8 @@
 
   "glm-copilot.config.maxTokens.description": "Maximum number of output tokens per request. Set to `0` to use the API default (no explicit limit). Useful for controlling costs.",
 
+  "glm-copilot.config.maxRetries.description": "Maximum automatic retries for transient chat failures (HTTP 429 rate limits and 5xx server errors), not counting the initial attempt. Set to `0` to disable automatic retries and fail fast. Retries wait with exponential backoff and honor the server's `Retry-After` header.",
+
   "glm-copilot.config.modelIdOverrides.description": "Remap a built-in model's API id. Keys are the model id shown in the picker (e.g. `glm-4.7`); values are the id sent to the API. Use this for proxies or regional endpoints (such as bigmodel.cn) that use different model names. To add brand-new models, use `customModels` instead.",
   "glm-copilot.config.customModels.description": "Add your own GLM models to the picker. Each entry is either a model id string (e.g. `\"glm-4.7\"`) or an object such as `{ \"id\": \"my-model\", \"name\": \"My Model\", \"maxInputTokens\": 200000 }`. Custom models always appear regardless of API Mode and are sent to the active endpoint.",
 

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -35,6 +35,8 @@
 
   "glm-copilot.config.maxTokens.description": "每次请求的最大输出 token 数。设为 `0` 表示使用 API 默认值（不限制）。可用于控制费用。",
 
+  "glm-copilot.config.maxRetries.description": "对瞬时失败（HTTP 429 限流和 5xx 服务器错误）的最大自动重试次数（不含首次请求）。设为 `0` 可关闭自动重试、失败时立即报错。重试采用指数退避，并遵循服务器返回的 `Retry-After`。",
+
   "glm-copilot.config.modelIdOverrides.description": "重映射内置模型的 API ID。键为选择器中显示的模型 ID（如 `glm-4.7`），值为发送给 API 的 ID。适用于使用不同模型名称的代理或区域端点（如 bigmodel.cn）。要添加全新模型，请改用 `customModels`。",
   "glm-copilot.config.customModels.description": "向选择器添加你自己的 GLM 模型。每个条目可以是模型 ID 字符串（如 `\"glm-4.7\"`），也可以是对象，如 `{ \"id\": \"my-model\", \"name\": \"My Model\", \"maxInputTokens\": 200000 }`。自定义模型始终显示（不受 API 模式过滤），并发送到当前生效的端点。",
 

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -21,6 +21,7 @@ export class GLMClient implements IGLMClient {
 		private baseUrl: string,
 		private apiKey: string,
 		private version: string,
+		private maxRetries: number,
 	) {}
 
 	/**
@@ -61,6 +62,7 @@ export class GLMClient implements IGLMClient {
 				},
 				{
 					baseUrl: this.baseUrl,
+					maxRetries: this.maxRetries,
 					cancellationToken,
 					onRetryBackoff: callbacks.onRetryBackoff,
 				},

--- a/src/client/retry.test.ts
+++ b/src/client/retry.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // retry.ts → ./errors → ../endpoint → ../config → 'vscode', and ../logger → ../config + vscode.window.
@@ -24,7 +26,12 @@ import {
 	computeBackoffDelay,
 } from './retry';
 import { GLMRequestError } from './errors';
-import { RETRY_BASE_DELAY_MS, RETRY_DEFAULT_MAX_RETRIES, RETRY_MAX_DELAY_MS } from '../consts';
+import {
+	RETRY_BASE_DELAY_MS,
+	RETRY_DEFAULT_MAX_RETRIES,
+	RETRY_MAX_DELAY_MS,
+	RETRY_MAX_RETRIES_CEILING,
+} from '../consts';
 
 const URL = 'https://api.z.ai/api/coding/paas/v4/chat/completions';
 const INIT: RequestInit = { method: 'POST', headers: {}, body: '{}' };
@@ -404,8 +411,17 @@ describe('fetchChatCompletionWithRetry', () => {
 		expect(fetchImpl).not.toHaveBeenCalled();
 	});
 
-	it('pins the default retry budget at 3', () => {
-		expect(RETRY_DEFAULT_MAX_RETRIES).toBe(3);
+	it('keeps the maxRetries setting schema in sync with the retry consts', () => {
+		const pkg = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf8')) as {
+			contributes: {
+				configuration: {
+					properties: Record<string, { default: number; maximum: number }>;
+				};
+			};
+		};
+		const setting = pkg.contributes.configuration.properties['glm-copilot.maxRetries'];
+		expect(setting.default).toBe(RETRY_DEFAULT_MAX_RETRIES);
+		expect(setting.maximum).toBe(RETRY_MAX_RETRIES_CEILING);
 	});
 
 	it('does not retry when maxRetries is 0 and surfaces the 429 immediately', async () => {

--- a/src/client/retry.test.ts
+++ b/src/client/retry.test.ts
@@ -24,7 +24,7 @@ import {
 	computeBackoffDelay,
 } from './retry';
 import { GLMRequestError } from './errors';
-import { RETRY_BASE_DELAY_MS, RETRY_MAX_ATTEMPTS, RETRY_MAX_DELAY_MS } from '../consts';
+import { RETRY_BASE_DELAY_MS, RETRY_DEFAULT_MAX_RETRIES, RETRY_MAX_DELAY_MS } from '../consts';
 
 const URL = 'https://api.z.ai/api/coding/paas/v4/chat/completions';
 const INIT: RequestInit = { method: 'POST', headers: {}, body: '{}' };
@@ -188,6 +188,7 @@ describe('fetchChatCompletionWithRetry', () => {
 		const fetchImpl = seqFetch([response(200, 'ok')]);
 		const res = await fetchChatCompletionWithRetry(URL, INIT, {
 			baseUrl: BASE_URL,
+			maxRetries: 3,
 			fetchImpl,
 			onRetryBackoff,
 		});
@@ -202,6 +203,7 @@ describe('fetchChatCompletionWithRetry', () => {
 		const fetchImpl = seqFetch([response(429, 'rate limited'), response(200, 'ok')]);
 		const promise = fetchChatCompletionWithRetry(URL, INIT, {
 			baseUrl: BASE_URL,
+			maxRetries: 3,
 			fetchImpl,
 			onRetryBackoff,
 		});
@@ -213,7 +215,7 @@ describe('fetchChatCompletionWithRetry', () => {
 		expect(onRetryBackoff).toHaveBeenCalledWith({
 			status: 429,
 			nextAttempt: 2,
-			maxAttempts: RETRY_MAX_ATTEMPTS,
+			maxAttempts: 4,
 			delayMs: expect.any(Number),
 		});
 	});
@@ -224,6 +226,7 @@ describe('fetchChatCompletionWithRetry', () => {
 		const fetchImpl = seqFetch([response(503, 'busy'), response(200, 'ok')]);
 		const promise = fetchChatCompletionWithRetry(URL, INIT, {
 			baseUrl: BASE_URL,
+			maxRetries: 3,
 			fetchImpl,
 			onRetryBackoff,
 		});
@@ -241,7 +244,7 @@ describe('fetchChatCompletionWithRetry', () => {
 		const onRetryBackoff = vi.fn();
 		const fetchImpl = seqFetch([response(400, 'bad request')]);
 		await expect(
-			fetchChatCompletionWithRetry(URL, INIT, { baseUrl: BASE_URL, fetchImpl, onRetryBackoff }),
+			fetchChatCompletionWithRetry(URL, INIT, { baseUrl: BASE_URL, maxRetries: 3, fetchImpl, onRetryBackoff }),
 		).rejects.toMatchObject({ name: 'GLMRequestError', status: 400 });
 		expect(fetchImpl).toHaveBeenCalledTimes(1);
 		expect(onRetryBackoff).not.toHaveBeenCalled();
@@ -250,29 +253,32 @@ describe('fetchChatCompletionWithRetry', () => {
 	it('does not retry HTTP 401', async () => {
 		const fetchImpl = seqFetch([response(401, 'unauthorized')]);
 		await expect(
-			fetchChatCompletionWithRetry(URL, INIT, { baseUrl: BASE_URL, fetchImpl }),
+			fetchChatCompletionWithRetry(URL, INIT, { baseUrl: BASE_URL, maxRetries: 3, fetchImpl }),
 		).rejects.toMatchObject({ name: 'GLMRequestError', status: 401 });
 		expect(fetchImpl).toHaveBeenCalledTimes(1);
 	});
 
-	it('throws a GLMRequestError with status 429 after exhausting all attempts', async () => {
+	it('throws a GLMRequestError with status 429 after exhausting maxRetries', async () => {
 		vi.useFakeTimers();
-		expect(RETRY_MAX_ATTEMPTS).toBe(10);
 		const fetchImpl = seqFetch(
-			Array.from({ length: RETRY_MAX_ATTEMPTS }, () => response(429, 'rate limited')),
+			Array.from({ length: 3 }, () => response(429, 'rate limited')),
 		);
-		const promise = fetchChatCompletionWithRetry(URL, INIT, { baseUrl: BASE_URL, fetchImpl });
+		const promise = fetchChatCompletionWithRetry(URL, INIT, {
+			baseUrl: BASE_URL,
+			maxRetries: 2,
+			fetchImpl,
+		});
 		// Attach a handler before flushing timers so the rejection isn't reported as unhandled.
 		promise.catch(() => {});
 		await vi.runAllTimersAsync();
 		await expect(promise).rejects.toMatchObject({ name: 'GLMRequestError', status: 429 });
-		expect(fetchImpl).toHaveBeenCalledTimes(RETRY_MAX_ATTEMPTS);
+		expect(fetchImpl).toHaveBeenCalledTimes(3);
 	});
 
 	it('throws a GLMRequestError instance (not a plain Error)', async () => {
 		const fetchImpl = seqFetch([response(400, 'bad request')]);
 		try {
-			await fetchChatCompletionWithRetry(URL, INIT, { baseUrl: BASE_URL, fetchImpl });
+			await fetchChatCompletionWithRetry(URL, INIT, { baseUrl: BASE_URL, maxRetries: 3, fetchImpl });
 			throw new Error('should have thrown');
 		} catch (error) {
 			expect(error).toBeInstanceOf(GLMRequestError);
@@ -285,7 +291,7 @@ describe('fetchChatCompletionWithRetry', () => {
 			response(429, 'rate limited', { 'retry-after': '2' }),
 			response(200, 'ok'),
 		]);
-		const promise = fetchChatCompletionWithRetry(URL, INIT, { baseUrl: BASE_URL, fetchImpl });
+		const promise = fetchChatCompletionWithRetry(URL, INIT, { baseUrl: BASE_URL, maxRetries: 3, fetchImpl });
 		// 2s must elapse before the second attempt fires.
 		await vi.advanceTimersByTimeAsync(1999);
 		expect(fetchImpl).toHaveBeenCalledTimes(1);
@@ -304,6 +310,7 @@ describe('fetchChatCompletionWithRetry', () => {
 		]);
 		const promise = fetchChatCompletionWithRetry(URL, INIT, {
 			baseUrl: BASE_URL,
+			maxRetries: 3,
 			fetchImpl,
 			onRetryBackoff,
 		});
@@ -326,6 +333,7 @@ describe('fetchChatCompletionWithRetry', () => {
 		const fetchImpl = seqFetch([response(429, 'rate limited'), response(200, 'ok')]);
 		const promise = fetchChatCompletionWithRetry(URL, INIT, {
 			baseUrl: BASE_URL,
+			maxRetries: 3,
 			fetchImpl,
 			onRetryBackoff,
 		});
@@ -346,7 +354,7 @@ describe('fetchChatCompletionWithRetry', () => {
 				response(429, 'rate limited'),
 				response(200, 'ok'),
 			]);
-			const promise = fetchChatCompletionWithRetry(URL, INIT, { baseUrl: BASE_URL, fetchImpl });
+			const promise = fetchChatCompletionWithRetry(URL, INIT, { baseUrl: BASE_URL, maxRetries: 3, fetchImpl });
 			// First retry scheduled at 1000ms (base * 2^0).
 			await vi.advanceTimersByTimeAsync(999);
 			expect(fetchImpl).toHaveBeenCalledTimes(1);
@@ -370,6 +378,7 @@ describe('fetchChatCompletionWithRetry', () => {
 		const fetchImpl = seqFetch([response(429, 'rate limited'), response(200, 'ok')]);
 		const promise = fetchChatCompletionWithRetry(URL, INIT, {
 			baseUrl: BASE_URL,
+			maxRetries: 3,
 			cancellationToken: token,
 			fetchImpl,
 		});
@@ -387,10 +396,45 @@ describe('fetchChatCompletionWithRetry', () => {
 		await expect(
 			fetchChatCompletionWithRetry(URL, INIT, {
 				baseUrl: BASE_URL,
+				maxRetries: 3,
 				cancellationToken: token,
 				fetchImpl,
 			}),
 		).rejects.toMatchObject({ name: 'AbortError' });
 		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+
+	it('pins the default retry budget at 3', () => {
+		expect(RETRY_DEFAULT_MAX_RETRIES).toBe(3);
+	});
+
+	it('does not retry when maxRetries is 0 and surfaces the 429 immediately', async () => {
+		const onRetryBackoff = vi.fn();
+		const fetchImpl = seqFetch([response(429, 'rate limited')]);
+		await expect(
+			fetchChatCompletionWithRetry(URL, INIT, {
+				baseUrl: BASE_URL,
+				maxRetries: 0,
+				fetchImpl,
+				onRetryBackoff,
+			}),
+		).rejects.toMatchObject({ name: 'GLMRequestError', status: 429 });
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+		expect(onRetryBackoff).not.toHaveBeenCalled();
+	});
+
+	it('treats a non-numeric maxRetries as 0 and fails fast', async () => {
+		const onRetryBackoff = vi.fn();
+		const fetchImpl = seqFetch([response(429, 'rate limited')]);
+		await expect(
+			fetchChatCompletionWithRetry(URL, INIT, {
+				baseUrl: BASE_URL,
+				maxRetries: Number.NaN,
+				fetchImpl,
+				onRetryBackoff,
+			}),
+		).rejects.toMatchObject({ name: 'GLMRequestError', status: 429 });
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+		expect(onRetryBackoff).not.toHaveBeenCalled();
 	});
 });

--- a/src/client/retry.ts
+++ b/src/client/retry.ts
@@ -1,5 +1,5 @@
 import type * as vscode from 'vscode';
-import { RETRY_BASE_DELAY_MS, RETRY_MAX_ATTEMPTS, RETRY_MAX_DELAY_MS } from '../consts';
+import { RETRY_BASE_DELAY_MS, RETRY_MAX_DELAY_MS } from '../consts';
 import { logger } from '../logger';
 import type { RetryBackoffInfo } from '../types';
 import { createHttpError, isAbortError, normalizeRequestError } from './errors';
@@ -54,6 +54,8 @@ export function computeBackoffDelay(
 
 export interface FetchWithRetryOptions {
 	baseUrl: string;
+	/** Automatic retries after the initial attempt; 0 disables retrying. */
+	maxRetries: number;
 	cancellationToken?: vscode.CancellationToken;
 	/** Test seam; defaults to the global `fetch`. */
 	fetchImpl?: typeof fetch;
@@ -75,7 +77,7 @@ export async function fetchChatCompletionWithRetry(
 	options: FetchWithRetryOptions,
 ): Promise<Response> {
 	const fetchImpl = options.fetchImpl ?? fetch;
-	const maxAttempts = RETRY_MAX_ATTEMPTS;
+	const maxAttempts = options.maxRetries + 1;
 	const token = options.cancellationToken;
 	for (let attempt = 0; ; attempt++) {
 		if (token?.isCancellationRequested) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { CONFIG_SECTION, DEFAULT_TOOLS_LIMIT, MODELS, USAGE_DEFAULT_REFRESH_MINUTES, USAGE_MAX_REFRESH_MINUTES, USAGE_MIN_REFRESH_MINUTES } from './consts';
+import { CONFIG_SECTION, DEFAULT_TOOLS_LIMIT, MODELS, RETRY_DEFAULT_MAX_RETRIES, RETRY_MAX_RETRIES_CEILING, USAGE_DEFAULT_REFRESH_MINUTES, USAGE_MAX_REFRESH_MINUTES, USAGE_MIN_REFRESH_MINUTES } from './consts';
 import { t } from './i18n';
 import type { ApiMode, CustomModelConfig, GLMModel, Region, ThinkingMode } from './types';
 
@@ -106,4 +106,10 @@ export function getUsageRefreshIntervalMinutes(): number {
 /** Whether the usage status-bar item should be shown. */
 export function getShowUsageStatusBar(): boolean {
 	return cfg().get<boolean>('showUsageStatusBar', true);
+}
+
+/** Automatic retries for transient chat failures (0 disables), clamped to 0–RETRY_MAX_RETRIES_CEILING. */
+export function getMaxRetries(): number {
+	const value = cfg().get<number>('maxRetries', RETRY_DEFAULT_MAX_RETRIES);
+	return Math.min(RETRY_MAX_RETRIES_CEILING, Math.max(0, Math.floor(value)));
 }

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -64,8 +64,6 @@ export const USAGE_REQUEST_TIMEOUT_MS = 10_000;
 export const RETRY_DEFAULT_MAX_RETRIES = 3;
 /** Highest value accepted from the `maxRetries` setting. */
 export const RETRY_MAX_RETRIES_CEILING = 10;
-/** Total attempts (initial + retries) for transient GLM API failures (429 / 5xx). */
-export const RETRY_MAX_ATTEMPTS = 10;
 /** Base delay (ms) for the first retry; doubles each attempt up to RETRY_MAX_DELAY_MS. */
 export const RETRY_BASE_DELAY_MS = 1000;
 /** Upper bound (ms) for a single backoff sleep, even when Retry-After is larger. */

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -60,6 +60,10 @@ export const USAGE_CACHE_STALE_MS = 60 * 60 * 1000;
 export const USAGE_MANUAL_DEBOUNCE_MS = 30 * 1000;
 export const USAGE_REQUEST_TIMEOUT_MS = 10_000;
 
+/** Default automatic retries (after the initial attempt) for transient GLM API failures (429 / 5xx). */
+export const RETRY_DEFAULT_MAX_RETRIES = 3;
+/** Highest value accepted from the `maxRetries` setting. */
+export const RETRY_MAX_RETRIES_CEILING = 10;
 /** Total attempts (initial + retries) for transient GLM API failures (429 / 5xx). */
 export const RETRY_MAX_ATTEMPTS = 10;
 /** Base delay (ms) for the first retry; doubles each attempt up to RETRY_MAX_DELAY_MS. */

--- a/src/provider/request.ts
+++ b/src/provider/request.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { GLMClient } from '../client';
-import { findModelDefinition, getApiModelId, getMaxTokens, getThinking } from '../config';
+import { findModelDefinition, getApiModelId, getMaxRetries, getMaxTokens, getThinking } from '../config';
 import { DEFAULT_TOOLS_LIMIT } from '../consts';
 import { resolveBaseUrl } from '../endpoint';
 import { t } from '../i18n';
@@ -44,7 +44,7 @@ export async function prepareChatRequest({
 		throw new Error(t('auth.notConfigured'));
 	}
 	const baseUrl = resolveBaseUrl();
-	const client = new GLMClient(baseUrl, apiKey, extensionVersion);
+	const client = new GLMClient(baseUrl, apiKey, extensionVersion, getMaxRetries());
 	const modelDef = findModelDefinition(modelInfo.id);
 	const isThinkingModel = modelDef?.capabilities.thinking ?? false;
 	const toolCalling = modelDef?.capabilities.toolCalling ?? false;


### PR DESCRIPTION
## Summary

- Replaces the hard-coded 10-attempt retry budget for chat requests with a `glm-copilot.maxRetries` setting (integer 0–10).
- `0` disables automatic retries entirely (fail fast when rate limited).
- Default lowered to 3 retries (4 total attempts); set 9 to restore the previous behavior.
- Retry progress messages and `Retry-After`-aware backoff are unchanged; the attempt counter shown to the user follows the configured limit automatically.
- Version bumped to 0.2.8 (README Marketplace badge moves with it, per repo convention). The first commit carries unrelated README/docs copy edits that were pending locally.

Closes #20

## Verification

- `pnpm typecheck && pnpm lint && pnpm test` pass locally (68/68 tests).
- New tests: `maxRetries: 0` fails fast without invoking the backoff observer; a non-numeric value (`NaN`) degrades to the same fail-fast; exhaustion honors a custom limit (`maxRetries: 2` → exactly 3 fetch calls); default pinned at 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `glm-copilot.maxRetries` setting to control automatic retries for transient chat failures, including an option to disable retries (0) and a 0–10 capped range.
  * Streaming usage is now included automatically in the final SSE chunk.

* **Bug Fixes**
  * Reduced the default retry budget for transient failures (now fewer total attempts).
  * Improved behavior for invalid retry values by treating them as no retries.

* **Documentation**
  * Updated README, changelog, API docs, and localization text to reflect the new setting and streaming usage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->