### PR TITLE
Handle usage API business errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 All notable changes to GLM Models for GitHub Copilot Chat are documented here.
 
+## [Unreleased]
+
+- **Usage error reporting** - HTTP 200 responses containing failed GLM business envelopes now report authentication or server errors instead of `no-data`. Business codes and server messages are preserved in the GLM output logs, and authentication failures provide the existing API-key recovery action.
+
 ## 0.2.10
 
 - **Standard API balance tracking** - the usage status bar and details panel now also work for the Standard API (pay-as-you-go) mode, not just Coding Plan. Cash balance (available, recharged, gifted, spent, frozen) and token resource packages are queried from both `z.ai` and `bigmodel.cn` account endpoints, which share the same JSON shape. The status bar turns red when the available balance reaches 0.

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -14,7 +14,18 @@ const SET_API_KEY_COMMAND = 'command:glm-copilot.setApiKey';
 /** VS Code command URI that reveals the extension log output. */
 const SHOW_LOGS_COMMAND = 'command:glm-copilot.showLogs';
 
-type RequestErrorKind = 'http' | 'network' | 'unknown';
+type RequestErrorKind = 'http' | 'network' | 'business' | 'response' | 'unknown';
+
+const AUTHENTICATION_BUSINESS_CODES = new Set([
+	'401',
+	'403',
+	'1000',
+	'1001',
+	'1002',
+	'1003',
+	'1004',
+	'1005',
+]);
 
 interface GLMRequestErrorOptions {
 	message: string;
@@ -191,6 +202,53 @@ export async function createHttpError(
 	});
 }
 
+/** Build a `GLMRequestError` from a failed JSON business envelope. */
+export function createBusinessError(context: {
+	baseUrl: string;
+	operation: string;
+	code?: string;
+	serverMessage?: string;
+}): GLMRequestError {
+	const codeLabel = context.code ?? 'UNKNOWN';
+	return new GLMRequestError({
+		message: `GLM API ${context.operation} failed with business code ${codeLabel}`,
+		kind: 'business',
+		baseUrl: context.baseUrl,
+		code: context.code,
+		diagnosticMessage: joinDiagnosticParts(
+			'kind=business',
+			`operation=${safeStringify(context.operation)}`,
+			context.code ? `businessCode=${safeStringify(context.code)}` : undefined,
+			`baseUrl=${safeStringify(context.baseUrl)}`,
+			context.serverMessage
+				? `serverMessage=${safeStringify(truncateSingleLine(context.serverMessage))}`
+				: undefined,
+		),
+	});
+}
+
+/** Build a `GLMRequestError` for an invalid JSON response body. */
+export function createResponseParseError(
+	context: { baseUrl: string; operation: string },
+	cause: unknown,
+): GLMRequestError {
+	const causeMessage = cause instanceof Error ? cause.message : String(cause);
+	return new GLMRequestError({
+		message: `GLM API ${context.operation} returned invalid JSON`,
+		kind: 'response',
+		baseUrl: context.baseUrl,
+		code: 'INVALID_JSON',
+		cause,
+		diagnosticMessage: joinDiagnosticParts(
+			'kind=response',
+			'code=INVALID_JSON',
+			`operation=${safeStringify(context.operation)}`,
+			`baseUrl=${safeStringify(context.baseUrl)}`,
+			`message=${safeStringify(truncateSingleLine(causeMessage))}`,
+		),
+	});
+}
+
 /** Categorize a thrown value into a `GLMRequestError`, or return it unchanged. */
 export function normalizeRequestError(
 	error: unknown,
@@ -265,6 +323,24 @@ export function formatRequestError(error: unknown): string {
 	return `error=${safeStringify(String(error))}`;
 }
 
+/**
+ * Return whether a structured request failure represents invalid authentication.
+ *
+ * @see https://docs.z.ai/api-reference/api-code
+ * @see https://docs.bigmodel.cn/cn/faq/api-code
+ */
+export function isAuthenticationRequestError(error: unknown): boolean {
+	if (!(error instanceof GLMRequestError)) {
+		return false;
+	}
+	if (error.kind === 'http') {
+		return error.status === 401 || error.status === 403;
+	}
+	return error.kind === 'business' &&
+		error.code !== undefined &&
+		AUTHENTICATION_BUSINESS_CODES.has(error.code);
+}
+
 function getHttpErrorMessage(status: number, statusLabel: string, baseUrl: string): string {
 	switch (status) {
 		case 400:
@@ -292,7 +368,7 @@ function getHttpErrorMessage(status: number, statusLabel: string, baseUrl: strin
 
 function getErrorActions(error: GLMRequestError): ErrorAction[] {
 	const actions: ErrorAction[] = [];
-	if (error.kind === 'http' && error.status === 401) {
+	if (isAuthenticationRequestError(error)) {
 		actions.push({ labelKey: 'error.action.setApiKey', url: SET_API_KEY_COMMAND });
 	}
 	actions.push({ labelKey: 'error.action.viewDetails', url: SHOW_LOGS_COMMAND });

--- a/src/client/response.test.ts
+++ b/src/client/response.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+	workspace: { getConfiguration: () => ({ get: () => undefined }) },
+	env: { language: 'en' },
+}));
+
+import { formatRequestError, isAuthenticationRequestError } from './errors';
+import { readBusinessJson } from './response';
+
+const CONTEXT = {
+	baseUrl: 'https://open.bigmodel.cn',
+	operation: 'account report',
+};
+
+describe('readBusinessJson', () => {
+	it.each([
+		401,
+		403,
+		1000,
+		1001,
+		1002,
+		1003,
+		1004,
+		1005,
+	])('classifies documented authentication business code %s', async (code) => {
+		const response = Response.json({
+			code,
+			msg: 'Authentication failed',
+			success: false,
+		});
+
+		let error: unknown;
+		try {
+			await readBusinessJson(response, CONTEXT);
+		} catch (caught) {
+			error = caught;
+		}
+
+		expect(isAuthenticationRequestError(error)).toBe(true);
+	});
+
+	it('does not classify an unrecognized business code as authentication', async () => {
+		const response = Response.json({
+			code: 9999,
+			msg: 'Business request failed',
+			success: false,
+		});
+
+		let error: unknown;
+		try {
+			await readBusinessJson(response, CONTEXT);
+		} catch (caught) {
+			error = caught;
+		}
+
+		expect(isAuthenticationRequestError(error)).toBe(false);
+	});
+
+	it('preserves cancellation while reading the response body', async () => {
+		const abortError = new DOMException('The operation was aborted.', 'AbortError');
+		const response = {
+			ok: true,
+			json: vi.fn(async () => {
+				throw abortError;
+			}),
+		} as unknown as Response;
+
+		await expect(readBusinessJson(response, CONTEXT)).rejects.toBe(abortError);
+	});
+
+	it('preserves a success-false business code and message in diagnostics', async () => {
+		const response = Response.json({
+			code: 1001,
+			msg: 'Authentication parameter not received in Header, unable to authenticate',
+			success: false,
+		});
+
+		let error: unknown;
+		try {
+			await readBusinessJson(response, CONTEXT);
+		} catch (caught) {
+			error = caught;
+		}
+
+		expect(isAuthenticationRequestError(error)).toBe(true);
+		expect(formatRequestError(error)).toContain('businessCode="1001"');
+		expect(formatRequestError(error)).toContain(
+			'serverMessage="Authentication parameter not received in Header, unable to authenticate"',
+		);
+	});
+
+	it('recognizes the official nested business-error shape', async () => {
+		const response = Response.json({
+			error: {
+				code: '1002',
+				message: 'Authorization Token is invalid',
+			},
+		});
+
+		await expect(readBusinessJson(response, CONTEXT)).rejects.toMatchObject({
+			kind: 'business',
+			code: '1002',
+		});
+	});
+
+	it('accepts business code 200', async () => {
+		const body = { code: 200, data: { limits: [] } };
+		const response = Response.json(body);
+
+		await expect(readBusinessJson(response, CONTEXT)).resolves.toEqual(body);
+	});
+});

--- a/src/client/response.test.ts
+++ b/src/client/response.test.ts
@@ -104,6 +104,30 @@ describe('readBusinessJson', () => {
 		});
 	});
 
+	it('prefers nested error details in a mixed business envelope', async () => {
+		const response = Response.json({
+			code: 200,
+			message: 'Request accepted',
+			error: {
+				code: 1002,
+				message: 'Authorization Token is invalid',
+			},
+		});
+
+		let error: unknown;
+		try {
+			await readBusinessJson(response, CONTEXT);
+		} catch (caught) {
+			error = caught;
+		}
+
+		expect(isAuthenticationRequestError(error)).toBe(true);
+		expect(formatRequestError(error)).toContain('businessCode="1002"');
+		expect(formatRequestError(error)).toContain(
+			'serverMessage="Authorization Token is invalid"',
+		);
+	});
+
 	it('accepts business code 200', async () => {
 		const body = { code: 200, data: { limits: [] } };
 		const response = Response.json(body);

--- a/src/client/response.ts
+++ b/src/client/response.ts
@@ -1,0 +1,96 @@
+import {
+	createBusinessError,
+	createHttpError,
+	createResponseParseError,
+	isAbortError,
+} from './errors';
+
+const SUCCESS_BUSINESS_CODES = new Set(['200']);
+
+interface JsonResponseContext {
+	baseUrl: string;
+	operation: string;
+}
+
+interface BusinessFailure {
+	code?: string;
+	message?: string;
+}
+
+/** Parse and validate an HTTP JSON response, including its top-level business envelope. */
+export async function readBusinessJson<T>(
+	response: Response,
+	context: JsonResponseContext,
+): Promise<T> {
+	if (!response.ok) {
+		throw await createHttpError(response, { baseUrl: context.baseUrl });
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = await response.json();
+	} catch (error) {
+		if (isAbortError(error)) {
+			throw error;
+		}
+		throw createResponseParseError(context, error);
+	}
+
+	const failure = getBusinessFailure(parsed);
+	if (failure) {
+		throw createBusinessError({
+			...context,
+			code: failure.code,
+			serverMessage: failure.message,
+		});
+	}
+	return parsed as T;
+}
+
+function getBusinessFailure(value: unknown): BusinessFailure | undefined {
+	const response = asRecord(value);
+	if (!response) {
+		return undefined;
+	}
+
+	const errorValue = response.error;
+	const errorObject = asRecord(errorValue);
+	const code = readCode(response.code) ?? readCode(errorObject?.code);
+	const message =
+		readString(response.msg) ??
+		readString(response.message) ??
+		readString(errorObject?.message) ??
+		readString(errorValue);
+	const failedBySuccess = response.success === false;
+	const failedByCode = code !== undefined && !SUCCESS_BUSINESS_CODES.has(code);
+	const failedByError = errorValue !== undefined && errorValue !== null;
+
+	return failedBySuccess || failedByCode || failedByError
+		? { code, message }
+		: undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === 'object' && value !== null
+		? value as Record<string, unknown>
+		: undefined;
+}
+
+function readCode(value: unknown): string | undefined {
+	if (typeof value === 'number' && Number.isFinite(value)) {
+		return String(value);
+	}
+	if (typeof value !== 'string') {
+		return undefined;
+	}
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+	if (typeof value !== 'string') {
+		return undefined;
+	}
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/src/client/response.ts
+++ b/src/client/response.ts
@@ -55,11 +55,11 @@ function getBusinessFailure(value: unknown): BusinessFailure | undefined {
 
 	const errorValue = response.error;
 	const errorObject = asRecord(errorValue);
-	const code = readCode(response.code) ?? readCode(errorObject?.code);
+	const code = readCode(errorObject?.code) ?? readCode(response.code);
 	const message =
+		readString(errorObject?.message) ??
 		readString(response.msg) ??
 		readString(response.message) ??
-		readString(errorObject?.message) ??
 		readString(errorValue);
 	const failedBySuccess = response.success === false;
 	const failedByCode = code !== undefined && !SUCCESS_BUSINESS_CODES.has(code);

--- a/src/client/usage.test.ts
+++ b/src/client/usage.test.ts
@@ -466,6 +466,29 @@ describe('UsageClient.fetchBalance (Standard API balance)', () => {
 		expect(snap.balance!.tokenPackages).toEqual([]);
 	});
 
+	it.each([
+		['totalSpendAmount', 'totalSpent'],
+		['giveAmount', 'giftedAmount'],
+		['frozenBalance', 'frozenAmount'],
+	] as const)(
+		'preserves account data from %s when token packages fail',
+		async (accountField, balanceField) => {
+			const client = new UsageClient(() => 'https://open.bigmodel.cn', mockFetch({
+				'query-customer-account-report': {
+					status: 200,
+					body: JSON.stringify({ success: true, data: { [accountField]: 12.5 } }),
+				},
+				'tokenAccounts/list/my': { status: 500, body: '' },
+			}));
+
+			const snap = await client.fetchBalance('k');
+
+			expect(snap.status).toBe('ok');
+			expect(snap.balance?.[balanceField]).toBe(12.5);
+			expect(snap.balance?.tokenPackages).toEqual([]);
+		},
+	);
+
 	it('propagates token-package cancellation even when cash data is usable', async () => {
 		const abortError = new DOMException('The operation was aborted.', 'AbortError');
 		const fetchImpl = vi.fn(async (url: URL | string) => {

--- a/src/client/usage.test.ts
+++ b/src/client/usage.test.ts
@@ -5,6 +5,16 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 vi.mock('vscode', () => ({
 	workspace: { getConfiguration: () => ({ get: () => undefined }) },
 	env: { language: 'en' },
+	window: {
+		createOutputChannel: () => ({
+			info: () => {},
+			warn: () => {},
+			error: () => {},
+			debug: () => {},
+			show: () => {},
+			dispose: () => {},
+		}),
+	},
 }));
 
 import { UsageClient } from './usage';
@@ -37,6 +47,21 @@ const QUOTA_NON_NUMERIC = JSON.stringify({
 	] },
 });
 const QUOTA_EMPTY = JSON.stringify({ data: { limits: [] } });
+const BUSINESS_AUTH_401 = JSON.stringify({
+	code: 401,
+	msg: 'Credential expired or incorrect',
+	success: false,
+});
+const BUSINESS_SERVER_ERROR = JSON.stringify({
+	code: 500,
+	msg: 'Internal Error',
+	success: false,
+});
+const BUSINESS_AUTH_1001 = JSON.stringify({
+	code: 1001,
+	msg: 'Authentication parameter not received in Header, unable to authenticate',
+	success: false,
+});
 
 function mockFetch(responses: Record<string, { status: number; body: string }>): typeof fetch {
 	return vi.fn(async (url: URL | string) => {
@@ -116,6 +141,62 @@ describe('UsageClient.fetchSnapshot', () => {
 		}));
 		const snap = await client.fetchSnapshot('k');
 		expect(snap.status).toBe('auth-error');
+	});
+
+	it.each([
+		'https://api.z.ai',
+		'https://open.bigmodel.cn',
+	])('maps HTTP 200 business code 401 to auth-error for %s', async (host) => {
+		const client = new UsageClient(host, mockFetch({
+			'subscription/list': { status: 200, body: BUSINESS_AUTH_401 },
+			'quota/limit': { status: 200, body: BUSINESS_AUTH_401 },
+		}));
+		const snap = await client.fetchSnapshot('k');
+		expect(snap.status).toBe('auth-error');
+	});
+
+	it('maps an HTTP 200 non-authentication business failure to server-error', async () => {
+		const client = new UsageClient('https://api.z.ai', mockFetch({
+			'subscription/list': { status: 200, body: SUBSCRIPTION_OK },
+			'quota/limit': { status: 200, body: BUSINESS_SERVER_ERROR },
+		}));
+		const snap = await client.fetchSnapshot('k');
+		expect(snap.status).toBe('server-error');
+	});
+
+	it('does not reduce a subscription business authentication failure to no-data', async () => {
+		const client = new UsageClient('https://api.z.ai', mockFetch({
+			'subscription/list': { status: 200, body: BUSINESS_AUTH_401 },
+			'quota/limit': { status: 200, body: QUOTA_EMPTY },
+		}));
+		const snap = await client.fetchSnapshot('k');
+		expect(snap.status).toBe('auth-error');
+	});
+
+	it('does not mask a subscription business authentication failure with usable quota', async () => {
+		const client = new UsageClient('https://api.z.ai', mockFetch({
+			'subscription/list': { status: 200, body: BUSINESS_AUTH_401 },
+			'quota/limit': { status: 200, body: QUOTA_SESSION_ONLY },
+		}));
+		const snap = await client.fetchSnapshot('k');
+		expect(snap.status).toBe('auth-error');
+	});
+
+	it('propagates subscription cancellation even when quota data is usable', async () => {
+		const abortError = new DOMException('The operation was aborted.', 'AbortError');
+		const fetchImpl = vi.fn(async (url: URL | string) => {
+			const path = typeof url === 'string' ? url : url.pathname;
+			if (path.includes('subscription/list')) {
+				throw abortError;
+			}
+			return new Response(QUOTA_SESSION_ONLY, {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}) as unknown as typeof fetch;
+		const client = new UsageClient('https://api.z.ai', fetchImpl);
+
+		await expect(client.fetchSnapshot('k')).rejects.toBe(abortError);
 	});
 
 	it('maps HTTP 500 to server-error', async () => {
@@ -347,6 +428,33 @@ describe('UsageClient.fetchBalance (Standard API balance)', () => {
 		expect(snap.status).toBe('auth-error');
 	});
 
+	it('maps official business authentication code 1001 to auth-error', async () => {
+		const client = new UsageClient(() => 'https://open.bigmodel.cn', mockFetch({
+			'query-customer-account-report': { status: 200, body: BUSINESS_AUTH_1001 },
+			'tokenAccounts/list/my': { status: 200, body: TOKEN_PACKAGES_EMPTY },
+		}));
+		const snap = await client.fetchBalance('k');
+		expect(snap.status).toBe('auth-error');
+	});
+
+	it('does not reduce a token-package business failure to no-data', async () => {
+		const client = new UsageClient(() => 'https://open.bigmodel.cn', mockFetch({
+			'query-customer-account-report': { status: 200, body: ACCOUNT_EMPTY },
+			'tokenAccounts/list/my': { status: 200, body: BUSINESS_SERVER_ERROR },
+		}));
+		const snap = await client.fetchBalance('k');
+		expect(snap.status).toBe('server-error');
+	});
+
+	it('does not mask a token-package business authentication failure with usable cash', async () => {
+		const client = new UsageClient(() => 'https://open.bigmodel.cn', mockFetch({
+			'query-customer-account-report': { status: 200, body: ACCOUNT_OK },
+			'tokenAccounts/list/my': { status: 200, body: BUSINESS_AUTH_1001 },
+		}));
+		const snap = await client.fetchBalance('k');
+		expect(snap.status).toBe('auth-error');
+	});
+
 	it('survives token packages failure (non-fatal), still shows cash', async () => {
 		const client = new UsageClient(() => 'https://open.bigmodel.cn', mockFetch({
 			'query-customer-account-report': { status: 200, body: ACCOUNT_OK },
@@ -356,6 +464,23 @@ describe('UsageClient.fetchBalance (Standard API balance)', () => {
 		expect(snap.status).toBe('ok');
 		expect(snap.balance!.availableCash).toBe(42.5);
 		expect(snap.balance!.tokenPackages).toEqual([]);
+	});
+
+	it('propagates token-package cancellation even when cash data is usable', async () => {
+		const abortError = new DOMException('The operation was aborted.', 'AbortError');
+		const fetchImpl = vi.fn(async (url: URL | string) => {
+			const path = typeof url === 'string' ? url : url.toString();
+			if (path.includes('tokenAccounts/list/my')) {
+				throw abortError;
+			}
+			return new Response(ACCOUNT_OK, {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}) as unknown as typeof fetch;
+		const client = new UsageClient(() => 'https://open.bigmodel.cn', fetchImpl);
+
+		await expect(client.fetchBalance('k')).rejects.toBe(abortError);
 	});
 
 	it('uses raw key auth (no Bearer) for bigmodel.cn balance endpoints', async () => {

--- a/src/client/usage.ts
+++ b/src/client/usage.ts
@@ -144,7 +144,10 @@ export class UsageClient implements IUsageClient {
 
 		const hasAccountData =
 			account.availableCash !== undefined ||
-			account.totalRecharged !== undefined;
+			account.totalRecharged !== undefined ||
+			account.totalSpent !== undefined ||
+			account.giftedAmount !== undefined ||
+			account.frozenAmount !== undefined;
 		if (packagesResult.status === 'rejected' && isAbortError(packagesResult.reason)) {
 			throw packagesResult.reason;
 		}

--- a/src/client/usage.ts
+++ b/src/client/usage.ts
@@ -1,6 +1,14 @@
 import { BALANCE_PATHS, USAGE_PATHS, USAGE_REQUEST_TIMEOUT_MS } from '../consts';
+import { logger } from '../logger';
 import type { TokenPackage, UsageBalance, UsageMetric, UsageSnapshot, UsageStatus } from '../types';
-import { createHttpError, isAbortError, normalizeRequestError } from './errors';
+import {
+	formatRequestError,
+	GLMRequestError,
+	isAbortError,
+	isAuthenticationRequestError,
+	normalizeRequestError,
+} from './errors';
+import { readBusinessJson } from './response';
 
 interface ZaiLimit {
 	type?: string;
@@ -58,7 +66,7 @@ export interface IUsageClient {
 /**
  * GLM usage + balance client. `fetchSnapshot` fetches Coding Plan quota (subscription + quota GETs);
  * `fetchBalance` fetches Standard API cash balance + token packages (two parallel GETs).
- * Subscription failure is swallowed; quota/balance failure sets status.
+ * Supplementary request failures preserve usable primary data and otherwise set the error status.
  *
  * Both stations (z.ai international + open.bigmodel.cn china) share the same paths and JSON
  * shapes; only the host and Authorization header differ. The China (open.bigmodel.cn) monitor
@@ -83,15 +91,33 @@ export class UsageClient implements IUsageClient {
 	/**
 	 * Fetch Coding Plan usage quota. Resolves the host, then fires subscription + quota requests in
 	 * parallel; the subscription result (plan name + renewal) is merged into the quota snapshot.
-	 * Subscription failure is swallowed (best-effort); quota failure determines the final status.
+	 * Subscription failure is best-effort when quota data is usable and otherwise determines the
+	 * error status instead of being reduced to `no-data`.
 	 */
 	async fetchSnapshot(apiKey: string, signal?: AbortSignal): Promise<UsageSnapshot> {
 		const host = this.resolveHost();
-		const [subscription, snapshot] = await Promise.all([
+		const [subscriptionResult, quotaResult] = await Promise.allSettled([
 			this.fetchSubscription(host, apiKey, signal),
 			this.fetchQuota(host, apiKey, signal),
 		]);
-		return { ...snapshot, ...subscription };
+		if (quotaResult.status === 'rejected') {
+			throw quotaResult.reason;
+		}
+		const snapshot = quotaResult.value;
+		if (subscriptionResult.status === 'fulfilled') {
+			return { ...snapshot, ...subscriptionResult.value };
+		}
+		if (isAbortError(subscriptionResult.reason)) {
+			throw subscriptionResult.reason;
+		}
+		if (
+			isAuthenticationRequestError(subscriptionResult.reason) ||
+			snapshot.status === 'no-data'
+		) {
+			return this.toErrorSnapshot(subscriptionResult.reason, host, snapshot.fetchedAt);
+		}
+		this.logRequestError(subscriptionResult.reason, host);
+		return snapshot;
 	}
 
 	/**
@@ -116,15 +142,25 @@ export class UsageClient implements IUsageClient {
 		}
 		const account = accountResult.value;
 
-		// Token packages failure is non-fatal — we still show cash balance.
+		const hasAccountData =
+			account.availableCash !== undefined ||
+			account.totalRecharged !== undefined;
+		if (packagesResult.status === 'rejected' && isAbortError(packagesResult.reason)) {
+			throw packagesResult.reason;
+		}
+		if (
+			packagesResult.status === 'rejected' &&
+			(isAuthenticationRequestError(packagesResult.reason) || !hasAccountData)
+		) {
+			return this.toErrorSnapshot(packagesResult.reason, host, fetchedAt);
+		}
+		if (packagesResult.status === 'rejected') {
+			this.logRequestError(packagesResult.reason, host);
+		}
 		const packages = packagesResult.status === 'fulfilled' ? packagesResult.value : [];
 
 		const balance: UsageBalance = { ...account, tokenPackages: packages };
-		// No data at all → no-data; otherwise ok even if some fields are missing.
-		const hasData =
-			account.availableCash !== undefined ||
-			account.totalRecharged !== undefined ||
-			packages.length > 0;
+		const hasData = hasAccountData || packages.length > 0;
 		return {
 			status: hasData ? 'ok' : 'no-data',
 			balance,
@@ -135,17 +171,17 @@ export class UsageClient implements IUsageClient {
 	/**
 	 * Fetch the cash account report (balance, recharge, spend, gift, frozen) from the biz gateway.
 	 * Throws on HTTP error so the caller can map it to an error status.
-	 */	private async fetchAccountReport(
+	 */
+	private async fetchAccountReport(
 		host: string,
 		apiKey: string,
 		signal?: AbortSignal,
 	): Promise<Omit<UsageBalance, 'tokenPackages'>> {
 		const response = await this.get(`${host}${BALANCE_PATHS.accountReport}`, apiKey, signal);
-		if (!response.ok) {
-			const error = await createHttpError(response, { baseUrl: host });
-			throw error;
-		}
-		const parsed = (await response.json()) as BigmodelAccountReport;
+		const parsed = await readBusinessJson<BigmodelAccountReport>(response, {
+			baseUrl: host,
+			operation: 'account report',
+		});
 		const d = parsed?.data;
 		return {
 			availableCash: finiteOr(d?.availableBalance ?? d?.balance),
@@ -157,8 +193,8 @@ export class UsageClient implements IUsageClient {
 	}
 
 	/**
-	 * Fetch the list of token resource packages. Returns `[]` on any failure (non-fatal: cash
-	 * balance is still shown). Filters to EFFECTIVE packages (plus any with a non-null balance).
+	 * Fetch the list of token resource packages. Filters to EFFECTIVE packages (plus any with a
+	 * non-null balance). The caller decides whether a failure can degrade to cash-only data.
 	 */
 	private async fetchTokenAccounts(
 		host: string,
@@ -167,10 +203,10 @@ export class UsageClient implements IUsageClient {
 	): Promise<TokenPackage[]> {
 		const url = `${host}${BALANCE_PATHS.tokenAccounts}?pageNum=1&pageSize=100`;
 		const response = await this.get(url, apiKey, signal);
-		if (!response.ok) {
-			return [];
-		}
-		const parsed = (await response.json()) as BigmodelTokenAccountsResponse;
+		const parsed = await readBusinessJson<BigmodelTokenAccountsResponse>(response, {
+			baseUrl: host,
+			operation: 'token accounts',
+		});
 		const rows = parsed?.rows;
 		if (!Array.isArray(rows)) {
 			return [];
@@ -187,31 +223,26 @@ export class UsageClient implements IUsageClient {
 	}
 
 	/**
-	 * Fetch the Coding Plan subscription (plan name + renewal time). Any failure returns an empty
-	 * object — the quota snapshot still renders without plan metadata.
+	 * Fetch the Coding Plan subscription plan name and renewal time.
 	 */
 	private async fetchSubscription(
 		host: string,
 		apiKey: string,
 		signal?: AbortSignal,
 	): Promise<{ planName?: string; renewsAt?: string }> {
-		try {
-			const response = await this.get(`${host}${USAGE_PATHS.subscription}`, apiKey, signal);
-			if (!response.ok) {
-				return {};
-			}
-			const data = (await response.json()) as ZaiSubscriptionResponse;
-			const first = data?.data?.[0];
-			if (!first) {
-				return {};
-			}
-			return {
-				planName: first.productName,
-				renewsAt: first.nextRenewTime,
-			};
-		} catch {
+		const response = await this.get(`${host}${USAGE_PATHS.subscription}`, apiKey, signal);
+		const data = await readBusinessJson<ZaiSubscriptionResponse>(response, {
+			baseUrl: host,
+			operation: 'subscription',
+		});
+		const first = data?.data?.[0];
+		if (!first) {
 			return {};
 		}
+		return {
+			planName: first.productName,
+			renewsAt: first.nextRenewTime,
+		};
 	}
 
 	/**
@@ -220,26 +251,18 @@ export class UsageClient implements IUsageClient {
 	 */
 	private async fetchQuota(host: string, apiKey: string, signal?: AbortSignal): Promise<UsageSnapshot> {
 		const fetchedAt = Date.now();
-		let response: Response;
+		let parsed: ZaiQuotaResponse;
 		try {
-			response = await this.get(`${host}${USAGE_PATHS.quota}`, apiKey, signal);
+			const response = await this.get(`${host}${USAGE_PATHS.quota}`, apiKey, signal);
+			parsed = await readBusinessJson<ZaiQuotaResponse>(response, {
+				baseUrl: host,
+				operation: 'quota',
+			});
 		} catch (error) {
-			// Re-throw aborts so the caller (UsageStatusBar) can swallow+log them per spec §7.2
-			// instead of rendering a server-error snapshot for a cancellation it caused.
 			if (isAbortError(error)) {
 				throw error;
 			}
 			return this.toErrorSnapshot(error, host, fetchedAt);
-		}
-		if (!response.ok) {
-			const error = await createHttpError(response, { baseUrl: host });
-			return this.toErrorSnapshot(error, host, fetchedAt);
-		}
-		let parsed: ZaiQuotaResponse;
-		try {
-			parsed = (await response.json()) as ZaiQuotaResponse;
-		} catch {
-			return { status: 'server-error', metrics: [], fetchedAt };
 		}
 		const limits = extractLimits(parsed);
 		if (!Array.isArray(limits) || limits.length === 0) {
@@ -301,28 +324,23 @@ export class UsageClient implements IUsageClient {
 	}
 
 	/**
-	 * Map a fetch error to a {@link UsageSnapshot} error status: 401/403 → `auth-error`,
-	 * network → `network-error`, everything else → `server-error`.
+	 * Map a structured request error to a {@link UsageSnapshot} status.
 	 */
 	private toErrorSnapshot(error: unknown, host: string, fetchedAt: number): UsageSnapshot {
 		const normalized = normalizeRequestError(error, { baseUrl: host });
-		let status: UsageStatus;
-		if (normalized instanceof Error && 'kind' in normalized) {
-			const kind = (normalized as { kind: string }).kind;
-			const httpStatus = (normalized as { status?: number }).status;
-			if (kind === 'http' && (httpStatus === 401 || httpStatus === 403)) {
-				status = 'auth-error';
-			} else if (kind === 'http') {
-				status = 'server-error';
-			} else if (kind === 'network') {
-				status = 'network-error';
-			} else {
-				status = 'server-error';
-			}
-		} else {
-			status = 'server-error';
+		logger.warn('GLM usage request failed:', formatRequestError(normalized));
+		let status: UsageStatus = 'server-error';
+		if (isAuthenticationRequestError(normalized)) {
+			status = 'auth-error';
+		} else if (normalized instanceof GLMRequestError && normalized.kind === 'network') {
+			status = 'network-error';
 		}
 		return { status, metrics: [], fetchedAt };
+	}
+
+	private logRequestError(error: unknown, host: string): void {
+		const normalized = normalizeRequestError(error, { baseUrl: host });
+		logger.warn('GLM supplementary usage request failed:', formatRequestError(normalized));
 	}
 }
 


### PR DESCRIPTION
## Summary

- validate HTTP JSON responses for top-level GLM business failures
- preserve business codes and server messages in structured diagnostics
- map documented authentication business codes to `auth-error`
- keep usable primary usage or balance data when supplementary requests fail

## Root cause

The usage clients treated HTTP status as the only success signal. GLM endpoints can return HTTP 200 with a failed business envelope, causing authentication and server failures to be interpreted as empty successful data.

## User impact

Usage status now reports authentication, network, and server failures accurately instead of incorrectly displaying `no-data`. Authentication failures also expose the existing API-key recovery action.

## Validation

- `pnpm test` — 108 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`

Closes #29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage/balance error reporting for GLM responses delivered with HTTP 200.
  * Authentication and server failures are no longer downgraded to “no data,” and business error codes/messages are preserved in logs.
  * Authentication failures consistently trigger the API-key recovery action.
  * Enhanced handling for cancellation, malformed business envelopes, and supplementary (token-packages) request degradation.
* **Documentation**
  * Updated changelog with notes about the improved usage error reporting. 
* **Tests**
  * Expanded coverage for business-envelope shapes and classification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->