### PR TITLE
fix(usage): support CREDIT_LIMIT quotas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to GLM Models for GitHub Copilot Chat are documented here.
 
 ## Unreleased
 
+- **Coding Plan credit-limit parsing** - accept the `CREDIT_LIMIT` quota entries now returned by Z.AI for 5-hour and weekly usage while retaining support for endpoints that still return `TOKENS_LIMIT`.
 - **Opt-in Standard API recovery** - when the current key exposes no usable Coding Plan quota, or its session/weekly token quota is exhausted, the GLM Usage panel can check that key's Standard API balance on demand. A switch is offered only when positive cash or token-package credit is found, and a modal discloses pay-as-you-go billing, the configuration scope, and model-availability changes before updating API Mode. No balance probe or mode change happens automatically; dismissal, failures, zero credit, monthly web-search exhaustion, and custom Base URLs leave the mode and key unchanged.
 
 ## 0.4.1

--- a/src/client/usage.test.ts
+++ b/src/client/usage.test.ts
@@ -35,6 +35,18 @@ const QUOTA_FULL = JSON.stringify({
 		],
 	},
 });
+const QUOTA_CREDIT_LIMIT = JSON.stringify({
+	code: 200,
+	msg: 'Operation successful',
+	data: {
+		limits: [
+			{ type: 'CREDIT_LIMIT', unit: 3, number: 5, usage: 28000, currentValue: 5184, remaining: 22815, percentage: 18, nextResetTime: 1788371521831 },
+			{ type: 'CREDIT_LIMIT', unit: 6, number: 1, usage: 140000, currentValue: 36192, remaining: 103807, percentage: 25, nextResetTime: 1788875329996 },
+		],
+		level: 'max',
+	},
+	success: true,
+});
 const QUOTA_SESSION_ONLY = JSON.stringify({
 	code: 200,
 	data: { limits: [{ type: 'TOKENS_LIMIT', percentage: 10, nextResetTime: 1738368000000, unit: 3 }] },
@@ -95,6 +107,44 @@ describe('UsageClient.fetchSnapshot', () => {
 		expect(snap.metrics[1]).toMatchObject({ used: 10, limit: 100, resetsAt: 1738972800000 });
 		expect(snap.metrics[2]).toMatchObject({ used: 1095, limit: 4000, resetsAt: 1738368000000 });
 		expect(snap.fetchedAt).toBeGreaterThan(0);
+	});
+
+	it('maps CREDIT_LIMIT quota to session and weekly metrics', async () => {
+		const client = new UsageClient('https://api.z.ai', mockFetch({
+			'subscription/list': { status: 200, body: SUBSCRIPTION_OK },
+			'quota/limit': { status: 200, body: QUOTA_CREDIT_LIMIT },
+		}));
+		const snap = await client.fetchSnapshot('k');
+		expect(snap.status).toBe('ok');
+		expect(snap.planName).toBe('GLM Coding Max');
+		expect(snap.metrics).toEqual([
+			{ kind: 'session', used: 18, limit: 100, resetsAt: 1788371521831 },
+			{ kind: 'weekly', used: 25, limit: 100, resetsAt: 1788875329996 },
+		]);
+	});
+
+	it('prefers TOKENS_LIMIT when both quota formats are present', async () => {
+		const quota = JSON.stringify({
+			code: 200,
+			data: {
+				limits: [
+					{ type: 'CREDIT_LIMIT', unit: 3, percentage: 18, nextResetTime: 1788371521831 },
+					{ type: 'TOKENS_LIMIT', unit: 3, percentage: 11, nextResetTime: 1788371521000 },
+					{ type: 'CREDIT_LIMIT', unit: 6, percentage: 25, nextResetTime: 1788875329996 },
+					{ type: 'TOKENS_LIMIT', unit: 6, percentage: 22, nextResetTime: 1788875329000 },
+				],
+			},
+			success: true,
+		});
+		const client = new UsageClient('https://api.z.ai', mockFetch({
+			'subscription/list': { status: 200, body: SUBSCRIPTION_OK },
+			'quota/limit': { status: 200, body: quota },
+		}));
+		const snap = await client.fetchSnapshot('k');
+		expect(snap.metrics).toEqual([
+			{ kind: 'session', used: 11, limit: 100, resetsAt: 1788371521000 },
+			{ kind: 'weekly', used: 22, limit: 100, resetsAt: 1788875329000 },
+		]);
 	});
 
 	it('coerces non-numeric fields to 0', async () => {

--- a/src/client/usage.ts
+++ b/src/client/usage.ts
@@ -414,12 +414,12 @@ function nextUtcFirstOfMonthMs(now: Date = new Date()): number {
 }
 
 /**
- * Map raw `TOKENS_LIMIT` / `TIME_LIMIT` entries to the ordered metric list
+ * Map raw `TOKENS_LIMIT` / `CREDIT_LIMIT` / `TIME_LIMIT` entries to the ordered metric list
  * (`session` → `weekly` → `web-searches`), skipping any window that is absent.
  */
 function buildMetrics(limits: ZaiLimit[]): UsageMetric[] {
 	const metrics: UsageMetric[] = [];
-	const session = findLimit(limits, 'TOKENS_LIMIT', 3);
+	const session = findLimit(limits, 'TOKENS_LIMIT', 3) ?? findLimit(limits, 'CREDIT_LIMIT', 3);
 	if (session) {
 		metrics.push({
 			kind: 'session',
@@ -428,7 +428,7 @@ function buildMetrics(limits: ZaiLimit[]): UsageMetric[] {
 			resetsAt: session.nextResetTime,
 		});
 	}
-	const weekly = findLimit(limits, 'TOKENS_LIMIT', 6);
+	const weekly = findLimit(limits, 'TOKENS_LIMIT', 6) ?? findLimit(limits, 'CREDIT_LIMIT', 6);
 	if (weekly) {
 		metrics.push({
 			kind: 'weekly',


### PR DESCRIPTION
## Summary

- recognize the `CREDIT_LIMIT` quota entries now returned by Z.AI for 5-hour and weekly Coding Plan usage
- retain `TOKENS_LIMIT` as the preferred format when both formats are present, without changing `TIME_LIMIT` web-search metrics
- add regression coverage for the reported response and mixed-format precedence, and document the fix under Unreleased

## Verification

- `pnpm exec vitest run src/client/usage.test.ts` (39 tests)
- `pnpm test` (21 files, 207 tests)
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`

Live Extension Host smoke testing was not run because no authorized Coding Max test key was available.

Fixes #50


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying 5-hour and weekly Coding Plan usage from Z.AI credit-limit data.
  * Preserved compatibility with existing token-limit usage data, prioritizing it when both formats are available.

* **Tests**
  * Added coverage for credit-limit usage metrics and mixed response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->