### PR TITLE
chore(release): prepare 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 All notable changes to GLM Models for GitHub Copilot Chat are documented here.
 
-## Unreleased
+## 0.4.2
 
 - **Coding Plan credit-limit parsing** - accept the `CREDIT_LIMIT` quota entries now returned by Z.AI for 5-hour and weekly usage while retaining support for endpoints that still return `TOKENS_LIMIT`.
 - **Opt-in Standard API recovery** - when the current key exposes no usable Coding Plan quota, or its session/weekly token quota is exhausted, the GLM Usage panel can check that key's Standard API balance on demand. A switch is offered only when positive cash or token-package credit is found, and a modal discloses pay-as-you-go billing, the configuration scope, and model-availability changes before updating API Mode. No balance probe or mode change happens automatically; dismissal, failures, zero credit, monthly web-search exhaustion, and custom Base URLs leave the mode and key unchanged.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GLM Models for GitHub Copilot Chat
 
-[![VS Marketplace Version](https://img.shields.io/badge/Marketplace-0.4.1-1f6feb)](https://marketplace.visualstudio.com/items?itemName=yijiazhen-qi.glm-for-github-copilot-chat)
+[![VS Marketplace Version](https://img.shields.io/badge/Marketplace-0.4.2-1f6feb)](https://marketplace.visualstudio.com/items?itemName=yijiazhen-qi.glm-for-github-copilot-chat)
 [![VS Marketplace Installs](https://vsmarketplacebadges.dev/installs-short/yijiazhen-qi.glm-for-github-copilot-chat.svg)](https://marketplace.visualstudio.com/items?itemName=yijiazhen-qi.glm-for-github-copilot-chat)
 [![Install from VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Install-007ACC)](https://marketplace.visualstudio.com/items?itemName=yijiazhen-qi.glm-for-github-copilot-chat)
 [![CI](https://github.com/KiwiGaze/glm-for-copilot/actions/workflows/ci.yml/badge.svg)](https://github.com/KiwiGaze/glm-for-copilot/actions/workflows/ci.yml)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "GLM Models for GitHub Copilot Chat",
 	"description": "Bring Z.ai / Zhipu GLM models into GitHub Copilot Chat with visible thinking and GLM-5.3-Flash image input.",
 	"icon": "resources/icon.png",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"publisher": "yijiazhen-qi",
 	"license": "MIT",
 	"repository": {


### PR DESCRIPTION
## Release 0.4.2

Promotes the two changes sitting under `## Unreleased` to version `0.4.2`.

### Ships in 0.4.2
- **Coding Plan credit-limit parsing** (#51) - accept the `CREDIT_LIMIT` quota entries now returned by Z.AI for 5-hour and weekly usage while retaining `TOKENS_LIMIT` support.
- **Opt-in Standard API recovery** (#49) - when the current key exposes no usable Coding Plan quota, or its session/weekly token quota is exhausted, the GLM Usage panel can check that key's Standard API balance on demand. A switch is offered only when positive credit is found, behind a pay-as-you-go disclosure modal; nothing happens automatically.

### Release chores
- `CHANGELOG.md`: `## Unreleased` → `## 0.4.2`
- `package.json`: `0.4.1` → `0.4.2`
- `README.md`: Marketplace badge → `Marketplace-0.4.2`

### Release audit (all green)

| Check | Result |
|---|---|
| Version consistency (`package.json` = README badge = 0.4.2; no stray refs) | ✅ |
| CHANGELOG format (flat bullets, no subsections, no dangling links) | ✅ |
| README commands table lists 8/8 contributed commands with exact NLS titles | ✅ |
| NLS parity (`package.nls.json` ↔ `package.nls.zh-cn.json`) | ✅ |
| Command registration (8/8 `registerCommand` in `src/`) | ✅ |
| `llms.txt` / `docs/glm-api.md` defer to README | ✅ |
| `pnpm run typecheck` | ✅ |
| `pnpm run lint` | ✅ |
| `pnpm run test` | ✅ 207/207 (21 files) |
| `vsce package --no-dependencies` | ✅ 56 files, 852.86 KB |

### After merge
1. Tag `v0.4.2` and push it — the Release workflow validates tag↔version, typechecks, packages the vsix, and creates the GitHub release.
2. Publish to the Marketplace with `vsce publish` (manual step requiring publisher auth; not verifiable locally).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the extension version to 0.4.2.
  - Published release notes covering Coding Plan credit-limit parsing and optional Standard API balance recovery.
  - Updated the Visual Studio Marketplace badge to reflect version 0.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->